### PR TITLE
Allow to request market cap and daily volumes for a set of coins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # coingecko-api-client
 C# implementation of a CoinGecko API client
+
+## How to regenerate C# API clients
+
+* If you work with external API, you probably need to update Change OpenAPI definition added to the project. It's usually openApi3.yaml file.
+* Do right click on the project and select Edit Project File. In the file change value of `GenerateApiClient` property to true.
+* Rebuild the project. `NSwag` target will be executed as post action.
+* The last thing to be done is to run integration test `OpenApiGeneratedCodeModifier` that will rewrite auto generated C# classes to use C# 9 features like records and init keyword.

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Constants.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Constants.cs
@@ -2,12 +2,21 @@
 {
     internal sealed class Constants
     {
-
-        internal const string BitConnect = "bitconnect";
-        public const string UsdCoin = "usd-coin";
-        internal const string Bitcoin = "bitcoin";
-        internal const string Usd = "usd";
         internal const string Bcc = "bcc";
 
+        internal static class Coins
+        {
+            internal const string BitConnect = "bitconnect";
+            internal const string UsdCoin = "usd-coin";
+            internal const string Bitcoin = "bitcoin";
+            internal const string Aave = "aave";
+        }
+
+        internal static class Currencies
+        {
+            internal const string Usd = "usd";
+            internal const string Bcc = "bcc";
+            internal const string Eth = "eth";
+        }
     }
 }

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinsClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinsClientTests.cs
@@ -37,7 +37,7 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Integration
         [Fact]
         public async Task CoinsAsync_should_return_a_valid_coindata_when_passing_a_valid_id()
         {
-            var result = await _coinsClient.CoinsAsync(Constants.BitConnect, "false");
+            var result = await _coinsClient.CoinsAsync(Constants.Coins.BitConnect, "false");
             var list = result.Result;
             EnsureAllJsonElementsWereMapped(list);
         }
@@ -45,9 +45,9 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Integration
         [Fact]
         public async Task HistoryAsync_should_historical_data_when_passing_valid_id()
         {
-            var history = await _coinsClient.HistoryAsync(Constants.BitConnect, "30-01-2021", "true");
+            var history = await _coinsClient.HistoryAsync(Constants.Coins.BitConnect, "30-01-2021", "true");
             history.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            history.Result.Id.Should().Be(Constants.BitConnect);
+            history.Result.Id.Should().Be(Constants.Coins.BitConnect);
             history.Result.Symbol.Should().Be(Constants.Bcc);
             history.Result.Name.Should().Be("Bitconnect");
             history.Result.Image.Thumb.Should().NotBeEmpty();

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/SimpleClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/SimpleClientTests.cs
@@ -24,9 +24,9 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Integration
         {
             var price = await _simpleClient.PriceAsync("bitcoin", "usd");
             price.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            price.Result.Keys.Should().Contain(Constants.Bitcoin);
-            price.Result[Constants.Bitcoin].Keys.Should().Contain(Constants.Usd);
-            price.Result[Constants.Bitcoin][Constants.Usd].Should().BeGreaterThan(0);
+            price.Result.Keys.Should().Contain(Constants.Coins.Bitcoin);
+            price.Result[Constants.Coins.Bitcoin].Keys.Should().Contain(Constants.Currencies.Usd);
+            price.Result[Constants.Coins.Bitcoin][Constants.Currencies.Usd].Should().BeGreaterThan(0);
             Thread.Sleep(TimeSpan.FromSeconds(5));
         }
 

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
-    <PackageReference Include="Trakx.Utils.Testing" Version="0.1.41" />
+    <PackageReference Include="Trakx.Utils.Testing" Version="0.2.4-006a258" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
@@ -186,11 +186,11 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Unit
             IDictionary<string, IDictionary<string, decimal?>> obj = new Dictionary<string, IDictionary<string, decimal?>>();
             obj[id] = new Dictionary<string, decimal?>
             {
-                [Constants.Usd] = coinPrice
+                [Constants.Currencies.Usd] = coinPrice
             };
             obj[currency] = new Dictionary<string, decimal?>
             {
-                [Constants.Usd] = currencyPrice
+                [Constants.Currencies.Usd] = currencyPrice
             };
             _simpleClient.PriceAsync(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(new Response<IDictionary<string, IDictionary<string, decimal?>>>(200, null, obj));
@@ -206,15 +206,15 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Unit
                 {
                     Current_price = new Dictionary<string, decimal?>
                     {
-                        {Constants.Usd, price}
+                        {Constants.Currencies.Usd, price}
                     },
                     Market_cap = new Dictionary<string, decimal?>
                     {
-                        {Constants.Usd, 0}
+                        {Constants.Currencies.Usd, 0}
                     },
                     Total_volume = new Dictionary<string, decimal?>
                     {
-                        {Constants.Usd, volume}
+                        {Constants.Currencies.Usd, volume}
                     },
                 }
             };

--- a/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
@@ -9,10 +9,11 @@ namespace Trakx.CoinGecko.ApiClient
     {
         Task<decimal?> GetLatestPrice(string coinGeckoId, string quoteCurrencyId = Constants.UsdCoin);
         Task<decimal?> GetPriceAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin);
-        Task<MarketData> GetMarketDataAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin);
+        Task<MarketData?> GetMarketDataAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin);
         Task<string?> GetCoinGeckoIdFromSymbol(string symbol);
         Task<IReadOnlyList<CoinList>> GetCoinList();
         Task<IDictionary<string, IDictionary<string, decimal?>>> GetAllPrices(string[] ids, string[]? vsCurrencies = null);
+        Task<IList<ExtendedPrice>> GetAllPricesExtended(string[] ids, string[]? vsCurrencies = null, bool includeMarketCap = false, bool include24HrVol = false);
         Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(string id, string vsCurrency,
             DateTimeOffset start, DateTimeOffset end, CancellationToken cancellationToken);
     }

--- a/src/Trakx.CoinGecko.ApiClient/Models/ExtendedPrice.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Models/ExtendedPrice.cs
@@ -1,0 +1,11 @@
+﻿namespace Trakx.CoinGecko.ApiClient
+{
+    public class ExtendedPrice
+    {
+        public string? CoinGeckoId { get; init; }
+        public string? Currency { get; init; }
+        public decimal Price { get; init; }
+        public decimal? MarketCap { get; init; }
+        public decimal? DailyVolume { get; init; }
+    }
+}

--- a/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
+++ b/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
@@ -29,7 +29,7 @@
     </PackageReference>
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Trakx.Utils" Version="0.1.41" />
+    <PackageReference Include="Trakx.Utils" Version="0.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
+++ b/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
@@ -29,7 +29,7 @@
     </PackageReference>
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Trakx.Utils" Version="0.2.3" />
+    <PackageReference Include="Trakx.Utils" Version="0.2.4-006a258" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* A wrapping method **GetAllPricesExtended** was added that takes not only prices but also market cap and daily volumes.
* Some existing integration tests were fixed.