### PR TITLE
`GetSupportedQuoteCurrencies` and convert prices if necessary

### DIFF
--- a/src/Trakx.CoinGecko.ApiClient.Tests/CoinGeckoIdsTestData.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/CoinGeckoIdsTestData.cs
@@ -9,7 +9,6 @@ public class CoinGeckoIdsTestData : IEnumerable<object[]>
     {
         yield return new object[] { "bitcoin" };
         yield return new object[] { "ethereum" };
-        yield return new object[] { "usd-coin" };
         yield return new object[] { "aave" };
         yield return new object[] { "pax-gold" };
         yield return new object[] { "uma" };

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CachedHttpClientHandlerTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CachedHttpClientHandlerTests.cs
@@ -52,7 +52,7 @@ public class CachedHttpClientHandlerTests : IDisposable
         var ids = allCoins.Where(c => c.Id != "0vix-protocol") //this coin is not quoted in USD
             .Take(howManyCoinsInTest).Select(c => c.Id);
         var latestPrices = ids
-            .Select(async id => await _client.GetLatestPrice(id, "usd"));
+            .Select(async id => await _client.GetLatestPrice(id, Constants.Usd));
         var stopWatch = new Stopwatch();
         stopWatch.Start();
         await Task.WhenAll(latestPrices.ToArray());

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTests.cs
@@ -148,11 +148,7 @@ public class CoinGeckoClientTests : CoinGeckoClientTestBase
     /// <summary>
     /// Asserts the prices collected from <see cref="SimpleClient.PriceAsync"/>
     /// and saved in a <see cref="MultiplePrices"/> result.
-    /// 
     /// </summary>
-    /// <param name="baseIds"></param>
-    /// <param name="unsupportedQuoteIds"></param>
-    /// <param name="result"></param>
     internal static void AssertMultiplePrices(MultiplePrices result,
         string[] baseIds,
         string[] quoteIds,

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinsClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinsClientTests.cs
@@ -53,7 +53,7 @@ public class CoinsClientTests : CoinGeckoClientTestBase
     [ClassData(typeof(CoinGeckoIdsTestData))]
     public async Task HistoryAsync_should_historical_data_when_passing_valid_id(string id)
     {
-        var history = await _coinsClient.HistoryAsync(id, "30-01-2021", localization: false);
+        var history = await _coinsClient.HistoryAsync(id, "30-01-2021", localization: true);
         history.StatusCode.Should().Be((int)HttpStatusCode.OK);
         history.Content.Id.Should().Be(id);
         history.Content.Symbol.Should().NotBeNullOrWhiteSpace();

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/GenerateApiClientChecker.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/GenerateApiClientChecker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Trakx.Common.Testing.Documentation.GenerateApiClient;
+using Xunit.Abstractions;
+
+namespace Trakx.CoinGecko.ApiClient.Tests.Integration;
+
+public class GenerateApiClientChecker : GenerateApiClientCheckerBase
+{
+    public GenerateApiClientChecker(ITestOutputHelper output)
+        : base(output, CreateProjectFileFinder())
+    {
+    }
+
+    private static IProjectFileFinder CreateProjectFileFinder()
+    {
+        var objectFromClientAssembly = new CoinGeckoApiConfiguration();
+        var currentDirectory = Environment.CurrentDirectory;
+        return new ProjectFileFinder(objectFromClientAssembly, currentDirectory);
+    }
+}

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/SimpleClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/SimpleClientTests.cs
@@ -25,7 +25,7 @@ public class SimpleClientTests : CoinGeckoClientTestBase
     [InlineData("binancecoin")]
     public async Task PriceAsync_should_return_price_when_passing_valid_symbol(string id)
     {
-        var price = await _simpleClient.PriceAsync(id, "usd").ConfigureAwait(true);
+        var price = await _simpleClient.PriceAsync(id, Constants.Usd).ConfigureAwait(true);
         price.StatusCode.Should().Be((int)HttpStatusCode.OK);
         price.Content.Keys.Should().Contain(id);
         price.Content[id].Keys.Should().Contain(Constants.Usd);

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="trakx.common.testing" Version="0.1.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
@@ -35,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="Trakx.Common.Testing" Version="0.1.0" />
     <PackageReference Include="Trakx.Common.Testing.Documentation" Version="0.1.0" />
   </ItemGroup>
 

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
@@ -54,7 +54,7 @@ public class CoinGeckoClientTests
     public async Task GetMarketDataAsOfFromId_should_return_valid_data_when_passing_valid_id()
     {
         var asOf = _mockCreator.GetUtcDateTime();
-        var asOfString = asOf.ToString("dd-MM-yyyy");
+        var asOfString = CoinGeckoClient.GetDateString(asOf);
 
         var coin = _mockCreator.GetString(10);
         var coinPrice = _mockCreator.GetPrice();
@@ -217,8 +217,10 @@ public class CoinGeckoClientTests
             }
         };
 
+        var timestamp = CoinGeckoClient.GetDateString(date);
+
         _coinsClient
-            .HistoryAsync(id, date.ToString("dd-MM-yyyy"), localization: false)
+            .HistoryAsync(id, timestamp, localization: false)
             .Returns(((CoinData)result).AsResponse());
     }
 

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
@@ -218,7 +218,7 @@ public class CoinGeckoClientTests
         };
 
         _coinsClient
-            .HistoryAsync(id, date.ToString("dd-MM-yyyy"), "False")
+            .HistoryAsync(id, date.ToString("dd-MM-yyyy"), localization: false)
             .Returns(((CoinData)result).AsResponse());
     }
 

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
@@ -192,15 +192,13 @@ public class CoinGeckoClientTests
 
     private void ConfigurePriceAsync(string id, string currency, decimal coinPrice, decimal currencyPrice)
     {
-        IDictionary<string, IDictionary<string, decimal?>> response = new Dictionary<string, IDictionary<string, decimal?>>
-        {
-            [id] = BagDecimal(coinPrice),
-            [currency] = BagDecimal(currencyPrice),
-        };
+        var bag = MultiplePricesTests.MakePriceBag();
+        bag[id] = BagDecimal(coinPrice);
+        bag[currency] = BagDecimal(currencyPrice);
 
         _simpleClient
             .PriceAsync(Arg.Any<string>(), Arg.Any<string>())
-            .Returns(response.AsResponse());
+            .Returns(bag.AsResponse());
     }
 
     private void ConfigureHistoryAsync(string id, DateTime date, decimal price, decimal volume)
@@ -249,11 +247,10 @@ public class CoinGeckoClientTests
         return supportedQuoteCurrencies;
     }
 
-    private static Dictionary<string, decimal?> BagDecimal(decimal value, string currency = Constants.Usd)
+    internal static Dictionary<string, decimal?> BagDecimal(decimal value, string currency = Constants.Usd)
     {
         return new() { [currency] = value };
     }
-
     #endregion
 
 }

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/CoinGeckoClientTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 using Trakx.Common.ApiClient.Extensions;
+using Trakx.Common.Extensions;
 using Trakx.Common.Testing.Mocks;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,12 +17,11 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Unit;
 
 public class CoinGeckoClientTests
 {
-
-    private readonly ICoinGeckoClient _coinGeckoClient;
     private readonly ISimpleClient _simpleClient;
     private readonly ICoinsClient _coinsClient;
     private readonly MockCreator _mockCreator;
     private readonly IMemoryCache _memoryCache;
+    private readonly CoinGeckoClient _coinGeckoClient;
 
     public CoinGeckoClientTests(ITestOutputHelper output)
     {
@@ -40,8 +40,13 @@ public class CoinGeckoClientTests
         var currency = _mockCreator.GetString(5);
         var coinPrice = _mockCreator.GetPrice();
         var currencyPrice = _mockCreator.GetPrice();
+
         ConfigurePriceAsync(id, currency, coinPrice, currencyPrice);
+
+        ConfigureSupportedQuoteCurrencies(Constants.Usd);
+
         var result = await _coinGeckoClient.GetLatestPrice(id, currency);
+
         result.Should().Be(coinPrice / currencyPrice);
     }
 
@@ -54,6 +59,7 @@ public class CoinGeckoClientTests
         var coin = _mockCreator.GetString(10);
         var coinPrice = _mockCreator.GetPrice();
         var coinVolume = _mockCreator.GetValue();
+
         ConfigureHistoryAsync(coin, asOf, coinPrice, coinVolume);
 
         var currency = _mockCreator.GetString(10);
@@ -71,9 +77,9 @@ public class CoinGeckoClientTests
         result.QuoteCurrency.Should().Be(coin);
 
         Expression<Predicate<object>> fxRatePredicate =
-            o =>  o.ToString()!.Contains(asOfString) && o.ToString()!.Contains("fx-rate") && o.ToString()!.Contains(currency);
+            o => o.ToString()!.Contains(asOfString) && o.ToString()!.Contains("fx-rate") && o.ToString()!.Contains(currency);
         Expression<Predicate<object>> marketDataPredicate =
-            o =>  o.ToString()!.Contains(asOfString) && o.ToString()!.Contains("market-data") && o.ToString()!.Contains(currency) && o.ToString()!.Contains(coin);
+            o => o.ToString()!.Contains(asOfString) && o.ToString()!.Contains("market-data") && o.ToString()!.Contains(currency) && o.ToString()!.Contains(coin);
 
         _memoryCache.Received(1).TryGetValue(Arg.Is(fxRatePredicate), out _);
         _memoryCache.Received(1).CreateEntry(Arg.Is(fxRatePredicate));
@@ -111,27 +117,28 @@ public class CoinGeckoClientTests
     }
 
     [Fact]
-    public async Task GetAllPrices_should_return_a_valid_list_of_prices_when_passing_valid_ids_and_currencies()
+    public async Task GetAllPrices_should_return_multiple_prices_when_passing_valid_ids_and_currencies()
     {
         var id = _mockCreator.GetString(10);
         var currency = _mockCreator.GetString(10);
         var coinPrice = _mockCreator.GetPrice();
         var currentPrice = _mockCreator.GetPrice();
+
         ConfigurePriceAsync(id, currency, coinPrice, currentPrice);
-        var result = await _coinGeckoClient.GetAllPrices(new[] { id }, new[] { currency });
-        result.Keys.Should().Contain(id);
-        result.Keys.Should().Contain(currency);
-        foreach (var prices in result.Values)
-        {
-            prices.Keys.Should().OnlyContain(f => f == "usd");
-            prices.Values.Should().OnlyContain(f => f > 0);
-        }
+
+        var baseIds = id.AsSingletonArray();
+        var quoteIds = currency.AsSingletonArray();
+        var supportedQuoteCurrencies = ConfigureSupportedQuoteCurrencies(Constants.Usd);
+
+        var result = await _coinGeckoClient.GetAllPrices(baseIds, quoteIds);
+
+        Integration.CoinGeckoClientTests.AssertMultiplePrices(result, baseIds, quoteIds, supportedQuoteCurrencies);
     }
 
     [Fact]
     public async Task GetMarketDataForDateRange_should_call_Range_and_transform_data()
     {
-        var dates = new double[] {1619756926435, 1619757185872};
+        var dates = new double[] { 1619756926435, 1619757185872 };
         var range = new Range
         {
             Market_caps = new List<TimestampedValue>
@@ -155,13 +162,16 @@ public class CoinGeckoClientTests
         var start = _mockCreator.GetUtcDateTimeOffset();
         var end = _mockCreator.GetUtcDateTimeOffset();
 
-        _coinsClient.RangeAsync(id, vsCurrency, start.ToUnixTimeSeconds(), end.ToUnixTimeSeconds(), CancellationToken.None)
+        _coinsClient
+            .RangeAsync(id, vsCurrency, start.ToUnixTimeSeconds(), end.ToUnixTimeSeconds(), CancellationToken.None)
             .Returns(range.AsResponse());
 
-        var result = await _coinGeckoClient.GetMarketDataForDateRange(id, vsCurrency, start, end, CancellationToken.None)
+        var result = await _coinGeckoClient
+            .GetMarketDataForDateRange(id, vsCurrency, start, end, CancellationToken.None)
             .ConfigureAwait(false);
 
-        await _coinsClient.Received(1)
+        await _coinsClient
+            .Received(1)
             .RangeAsync(id, vsCurrency, start.ToUnixTimeSeconds(), end.ToUnixTimeSeconds(), CancellationToken.None)
             .ConfigureAwait(false);
 
@@ -180,19 +190,16 @@ public class CoinGeckoClientTests
 
     #region Helper Methods
 
-    private void ConfigurePriceAsync(string id, string currency, decimal? coinPrice,
-        decimal? currencyPrice)
+    private void ConfigurePriceAsync(string id, string currency, decimal coinPrice, decimal currencyPrice)
     {
-        IDictionary<string, IDictionary<string, decimal?>> response = new Dictionary<string, IDictionary<string, decimal?>>();
-        response[id] = new Dictionary<string, decimal?>
+        IDictionary<string, IDictionary<string, decimal?>> response = new Dictionary<string, IDictionary<string, decimal?>>
         {
-            [Constants.Usd] = coinPrice
+            [id] = BagDecimal(coinPrice),
+            [currency] = BagDecimal(currencyPrice),
         };
-        response[currency] = new Dictionary<string, decimal?>
-        {
-            [Constants.Usd] = currencyPrice
-        };
-        _simpleClient.PriceAsync(Arg.Any<string>(), Arg.Any<string>())
+
+        _simpleClient
+            .PriceAsync(Arg.Any<string>(), Arg.Any<string>())
             .Returns(response.AsResponse());
     }
 
@@ -204,21 +211,14 @@ public class CoinGeckoClientTests
             Symbol = id,
             Market_data = new Market_data
             {
-                Current_price = new Dictionary<string, decimal?>
-                {
-                    {Constants.Usd, price}
-                },
-                Market_cap = new Dictionary<string, decimal?>
-                {
-                    {Constants.Usd, 0}
-                },
-                Total_volume = new Dictionary<string, decimal?>
-                {
-                    {Constants.Usd, volume}
-                },
+                Market_cap = BagDecimal(0),
+                Total_volume = BagDecimal(volume),
+                Current_price = BagDecimal(price),
             }
         };
-        _coinsClient.HistoryAsync(id, date.ToString("dd-MM-yyyy"), "False")
+
+        _coinsClient
+            .HistoryAsync(id, date.ToString("dd-MM-yyyy"), "False")
             .Returns(((CoinData)result).AsResponse());
     }
 
@@ -231,8 +231,25 @@ public class CoinGeckoClientTests
                 Symbol = symbol ?? _mockCreator.GetString(30)
             }).ToList();
 
-        _coinsClient.ListAllAsync()
+        _coinsClient
+            .ListAllAsync()
             .Returns(list.AsResponse());
+    }
+
+    private List<string> ConfigureSupportedQuoteCurrencies(params string[] quoteCurrencies)
+    {
+        var supportedQuoteCurrencies = quoteCurrencies.ToList();
+
+        _simpleClient
+            .Supported_vs_currenciesAsync()
+            .Returns(supportedQuoteCurrencies.AsResponse());
+
+        return supportedQuoteCurrencies;
+    }
+
+    private static Dictionary<string, decimal?> BagDecimal(decimal value, string currency = Constants.Usd)
+    {
+        return new() { [currency] = value };
     }
 
     #endregion

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
@@ -7,20 +7,22 @@ namespace Trakx.CoinGecko.ApiClient.Tests.Unit;
 
 public class MultiplePricesTests
 {
+    private const string Coin1 = "coin1";
+
     [Fact]
     public void GetPrice_returns_direct_price()
     {
         const string mainCurrency = "eur";
 
         var source = MakePriceBag();
-        source["coin1"] = MakeDecimalBag();
+        source[Coin1] = MakeDecimalBag();
         source["coin2"] = MakeDecimalBag();
-        source["coin1"][mainCurrency] = 100m;
+        source[Coin1][mainCurrency] = 100m;
         source["coin2"][mainCurrency] = 200m;
 
         var prices = new MultiplePrices(source);
 
-        var price = prices.GetPrice("coin1", mainCurrency);
+        var price = prices.GetPrice(Coin1, mainCurrency);
         price.Should().Be(100m);
     }
 
@@ -40,16 +42,16 @@ public class MultiplePricesTests
         var expectedPrice = basePriceInMainCurrency * rateBetweenMainAndWanted;
 
         var source = MakePriceBag();
-        source["coin1"] = MakeDecimalBag();
+        source[Coin1] = MakeDecimalBag();
         source["coin2"] = MakeDecimalBag();
         source[wantedQuoteCurrency] = MakeDecimalBag();
 
-        source["coin1"][mainCurrency] = basePriceInMainCurrency;
+        source[Coin1][mainCurrency] = basePriceInMainCurrency;
         source[wantedQuoteCurrency][mainCurrency] = rateBetweenWantedAndMain;
 
         var prices = new MultiplePrices(source);
 
-        var price = prices.GetPrice("coin1", wantedQuoteCurrency);
+        var price = prices.GetPrice(Coin1, wantedQuoteCurrency);
         price.Should().Be(expectedPrice);
     }
 

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Trakx.CoinGecko.ApiClient.Models;
+using Xunit;
+
+namespace Trakx.CoinGecko.ApiClient.Tests.Unit;
+
+public class MultiplePricesTests
+{
+    [Fact]
+    public void GetPrice_returns_direct_price()
+    {
+        var mainCurrency = "eur";
+
+        var source = MakePriceBag();
+        source["coin1"] = MakeDecimalBag();
+        source["coin2"] = MakeDecimalBag();
+        source["coin1"][mainCurrency] = 100m;
+        source["coin2"][mainCurrency] = 200m;
+
+        var prices = new MultiplePrices(source);
+
+        var price = prices.GetPrice("coin1", mainCurrency);
+        price.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetPrice_returns_converted_price()
+    {
+        var mainCurrency = "eur";
+        var wantedQuoteCurrency = "gbp";
+
+        var basePriceInMainCurrency = 100m;
+
+        var rateBetweenWantedAndMain = 1.17m; // the price of 1 GBP in EUR
+        var rateBetweenMainAndWanted = 1 / rateBetweenWantedAndMain;
+
+        // in pure maths, the formula is: B / Q = (B / M) * (M / Q)
+        // base / wanted quote = (base / main currency) * (main currency / wanted quote)
+        var expectedPrice = basePriceInMainCurrency * rateBetweenMainAndWanted;
+
+        var source = MakePriceBag();
+        source["coin1"] = MakeDecimalBag();
+        source["coin2"] = MakeDecimalBag();
+        source[wantedQuoteCurrency] = MakeDecimalBag();
+
+        source["coin1"][mainCurrency] = basePriceInMainCurrency;
+        source[wantedQuoteCurrency][mainCurrency] = rateBetweenWantedAndMain;
+
+        var prices = new MultiplePrices(source);
+
+        var price = prices.GetPrice("coin1", wantedQuoteCurrency);
+        price.Should().Be(expectedPrice);
+    }
+
+    internal static IDictionary<string, IDictionary<string, decimal?>> MakePriceBag()
+    {
+        return new Dictionary<string, IDictionary<string, decimal?>>();
+    }
+
+    internal static IDictionary<string, decimal?> MakeDecimalBag()
+    {
+        return new Dictionary<string, decimal?>();
+    }
+}

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
@@ -39,7 +39,7 @@ public class MultiplePricesTests
 
         // in pure maths, the formula is: B / Q = (B / M) * (M / Q)
         // base / wanted quote = (base / main currency) * (main currency / wanted quote)
-        var expectedPrice = basePriceInMainCurrency * rateBetweenMainAndWanted;
+        const decimal expectedPrice = basePriceInMainCurrency * rateBetweenMainAndWanted;
 
         var source = MakePriceBag();
         source[Coin1] = MakeDecimalBag();

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Unit/MultiplePricesTests.cs
@@ -10,7 +10,7 @@ public class MultiplePricesTests
     [Fact]
     public void GetPrice_returns_direct_price()
     {
-        var mainCurrency = "eur";
+        const string mainCurrency = "eur";
 
         var source = MakePriceBag();
         source["coin1"] = MakeDecimalBag();
@@ -27,13 +27,13 @@ public class MultiplePricesTests
     [Fact]
     public void GetPrice_returns_converted_price()
     {
-        var mainCurrency = "eur";
-        var wantedQuoteCurrency = "gbp";
+        const string mainCurrency = "eur";
+        const string wantedQuoteCurrency = "gbp";
 
-        var basePriceInMainCurrency = 100m;
+        const decimal basePriceInMainCurrency = 100m;
 
-        var rateBetweenWantedAndMain = 1.17m; // the price of 1 GBP in EUR
-        var rateBetweenMainAndWanted = 1 / rateBetweenWantedAndMain;
+        const decimal rateBetweenWantedAndMain = 1.17m; // the price of 1 GBP in EUR
+        const decimal rateBetweenMainAndWanted = 1 / rateBetweenWantedAndMain;
 
         // in pure maths, the formula is: B / Q = (B / M) * (M / Q)
         // base / wanted quote = (base / main currency) * (main currency / wanted quote)

--- a/src/Trakx.CoinGecko.ApiClient/AddCoinGeckoClientExtension.cs
+++ b/src/Trakx.CoinGecko.ApiClient/AddCoinGeckoClientExtension.cs
@@ -16,13 +16,11 @@ public static partial class AddCoinGeckoClientExtension
     public static IServiceCollection AddCoinGeckoClient(
         this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddOptions();
-        services.Configure<CoinGeckoApiConfiguration>(configuration.GetSection(nameof(CoinGeckoApiConfiguration)));
-        var typedConfig = configuration.GetSection(nameof(CoinGeckoApiConfiguration))
-            .Get<CoinGeckoApiConfiguration>();
-        AddCoinGeckoClient(services, typedConfig);
+        var section = configuration.GetSection(nameof(CoinGeckoApiConfiguration));
+        services.Configure<CoinGeckoApiConfiguration>(section);
 
-        return services;
+        var typedConfig = section.Get<CoinGeckoApiConfiguration>()!;
+        return services.AddCoinGeckoClient(typedConfig);
     }
 
     public static IServiceCollection AddCoinGeckoClient(

--- a/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
@@ -252,7 +252,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="include_last_updated_at">&lt;b&gt;true/false&lt;/b&gt; to include last_updated_at of price, &lt;b&gt;default: false&lt;/b&gt;</param>
         /// <returns>List all coins with id, name, and symbol</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, decimal?>>>> PriceAsync(string ids, string vs_currencies, string include_market_cap = null, string include_24hr_vol = null, string include_24hr_change = null, string include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, decimal?>>>> PriceAsync(string ids, string vs_currencies, bool? include_market_cap = null, bool? include_24hr_vol = null, bool? include_24hr_change = null, bool? include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -268,7 +268,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="include_last_updated_at">&lt;b&gt;true/false&lt;/b&gt; to include last_updated_at of price, &lt;b&gt;default: false&lt;/b&gt;</param>
         /// <returns>price(s) of cryptocurrency</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response> Token_priceAsync(string id, string contract_addresses, string vs_currencies, string include_market_cap = null, string include_24hr_vol = null, string include_24hr_change = null, string include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response> Token_priceAsync(string id, string contract_addresses, string vs_currencies, bool? include_market_cap = null, bool? include_24hr_vol = null, bool? include_24hr_change = null, bool? include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -321,7 +321,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="include_last_updated_at">&lt;b&gt;true/false&lt;/b&gt; to include last_updated_at of price, &lt;b&gt;default: false&lt;/b&gt;</param>
         /// <returns>List all coins with id, name, and symbol</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, decimal?>>>> PriceAsync(string ids, string vs_currencies, string include_market_cap = null, string include_24hr_vol = null, string include_24hr_change = null, string include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, decimal?>>>> PriceAsync(string ids, string vs_currencies, bool? include_market_cap = null, bool? include_24hr_vol = null, bool? include_24hr_change = null, bool? include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (ids == null)
                 throw new System.ArgumentNullException("ids");
@@ -424,7 +424,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="include_last_updated_at">&lt;b&gt;true/false&lt;/b&gt; to include last_updated_at of price, &lt;b&gt;default: false&lt;/b&gt;</param>
         /// <returns>price(s) of cryptocurrency</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response> Token_priceAsync(string id, string contract_addresses, string vs_currencies, string include_market_cap = null, string include_24hr_vol = null, string include_24hr_change = null, string include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response> Token_priceAsync(string id, string contract_addresses, string vs_currencies, bool? include_market_cap = null, bool? include_24hr_vol = null, bool? include_24hr_change = null, bool? include_last_updated_at = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
@@ -743,7 +743,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="sparkline">Include sparkline 7 days data (eg. true, false) &lt;b&gt;[default: false]&lt;/b&gt;</param>
         /// <returns>Get current data for a coin</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response<CoinFullData>> CoinsAsync(string id, string localization = null, bool? tickers = null, bool? market_data = null, bool? community_data = null, bool? developer_data = null, bool? sparkline = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response<CoinFullData>> CoinsAsync(string id, bool? localization = null, bool? tickers = null, bool? market_data = null, bool? community_data = null, bool? developer_data = null, bool? sparkline = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -763,7 +763,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="depth">flag to show 2% orderbook depth. valid values: true, false</param>
         /// <returns>Get coin tickers</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response> TickersAsync(string id, string exchange_ids = null, string include_exchange_logo = null, int? page = null, string order = null, string depth = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response> TickersAsync(string id, string exchange_ids = null, string include_exchange_logo = null, int? page = null, string order = null, bool? depth = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -777,7 +777,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="localization">Set to false to exclude localized languages in response</param>
         /// <returns>Get historical data at a given date for a coin</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response<CoinData>> HistoryAsync(string id, string date, string localization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response<CoinData>> HistoryAsync(string id, string date, bool? localization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -1097,7 +1097,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="sparkline">Include sparkline 7 days data (eg. true, false) &lt;b&gt;[default: false]&lt;/b&gt;</param>
         /// <returns>Get current data for a coin</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response<CoinFullData>> CoinsAsync(string id, string localization = null, bool? tickers = null, bool? market_data = null, bool? community_data = null, bool? developer_data = null, bool? sparkline = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response<CoinFullData>> CoinsAsync(string id, bool? localization = null, bool? tickers = null, bool? market_data = null, bool? community_data = null, bool? developer_data = null, bool? sparkline = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
@@ -1208,7 +1208,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="depth">flag to show 2% orderbook depth. valid values: true, false</param>
         /// <returns>Get coin tickers</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response> TickersAsync(string id, string exchange_ids = null, string include_exchange_logo = null, int? page = null, string order = null, string depth = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response> TickersAsync(string id, string exchange_ids = null, string include_exchange_logo = null, int? page = null, string order = null, bool? depth = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
@@ -1303,7 +1303,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="localization">Set to false to exclude localized languages in response</param>
         /// <returns>Get historical data at a given date for a coin</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response<CoinData>> HistoryAsync(string id, string date, string localization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response<CoinData>> HistoryAsync(string id, string date, bool? localization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
@@ -4565,7 +4565,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="to_date">lists events before this date yyyy-mm-dd (set upcoming_events_only to false if fetching past events)</param>
         /// <returns>List events</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response> EventsAsync(string country_code = null, string type = null, string page = null, string upcoming_events_only = null, string from_date = null, string to_date = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response> EventsAsync(string country_code = null, string type = null, string page = null, bool? upcoming_events_only = null, string from_date = null, string to_date = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -4633,7 +4633,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// <param name="to_date">lists events before this date yyyy-mm-dd (set upcoming_events_only to false if fetching past events)</param>
         /// <returns>List events</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response> EventsAsync(string country_code = null, string type = null, string page = null, string upcoming_events_only = null, string from_date = null, string to_date = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response> EventsAsync(string country_code = null, string type = null, string page = null, bool? upcoming_events_only = null, string from_date = null, string to_date = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/events?");

--- a/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
@@ -6,7 +6,6 @@
 
 using Trakx.Common.ApiClient;
 
-#pragma warning disable CS0618
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
 #pragma warning disable 472 // Disable "CS0472 The result of the expression is always 'false' since a value of type 'Int32' is never equal to 'null' of type 'Int32?'
@@ -93,7 +92,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -276,7 +275,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// </summary>
         /// <returns>list of supported_vs_currencies</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Response> Supported_vs_currenciesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Response<System.Collections.Generic.List<string>>> Supported_vs_currenciesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
     }
 
@@ -367,7 +366,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -473,7 +472,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -517,7 +516,7 @@ namespace Trakx.CoinGecko.ApiClient
         /// </summary>
         /// <returns>list of supported_vs_currencies</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Response> Supported_vs_currenciesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Response<System.Collections.Generic.List<string>>> Supported_vs_currenciesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/simple/supported_vs_currencies");
@@ -529,6 +528,7 @@ namespace Trakx.CoinGecko.ApiClient
                 using (var request_ = new System.Net.Http.HttpRequestMessage())
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -537,7 +537,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -553,7 +553,12 @@ namespace Trakx.CoinGecko.ApiClient
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            return new Response(status_, headers_);
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.List<string>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return new Response<System.Collections.Generic.List<string>>(status_, headers_, objectResponse_.Object);
                         }
                         else
                         {
@@ -911,7 +916,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1028,7 +1033,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1141,7 +1146,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1247,7 +1252,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1331,7 +1336,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1426,7 +1431,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1517,7 +1522,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1601,7 +1606,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1697,7 +1702,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1959,7 +1964,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2047,7 +2052,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2140,7 +2145,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2445,7 +2450,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2512,7 +2517,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2588,7 +2593,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2689,7 +2694,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2772,7 +2777,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2850,7 +2855,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3092,7 +3097,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3180,7 +3185,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3445,7 +3450,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3528,7 +3533,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3595,7 +3600,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3673,7 +3678,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3932,7 +3937,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4015,7 +4020,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4093,7 +4098,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4160,7 +4165,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4399,7 +4404,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4672,7 +4677,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4739,7 +4744,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4806,7 +4811,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5020,7 +5025,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5234,7 +5239,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5459,7 +5464,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5526,7 +5531,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5674,16 +5679,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record CoinList
+    public partial class CoinList
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; init; }
+        public string Id { get; set; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; init; }
+        public string Symbol { get; set; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; init; }
+        public string Name { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5697,34 +5702,34 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record CoinData
+    public partial class CoinData
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; init; }
+        public string Id { get; set; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; init; }
+        public string Symbol { get; set; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; init; }
+        public string Name { get; set; }
 
         [Newtonsoft.Json.JsonProperty("localization", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Localization { get; set; }
 
         [Newtonsoft.Json.JsonProperty("image", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Image Image { get; init; }
+        public Image Image { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_data", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Market_data Market_data { get; init; }
+        public Market_data Market_data { get; set; }
 
         [Newtonsoft.Json.JsonProperty("community_data", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Community_data { get; init; }
+        public object Community_data { get; set; }
 
         [Newtonsoft.Json.JsonProperty("developer_data", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Developer_data { get; init; }
+        public object Developer_data { get; set; }
 
         [Newtonsoft.Json.JsonProperty("public_interest_stats", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Public_interest_stats { get; init; }
+        public object Public_interest_stats { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5738,96 +5743,96 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record CoinFullData : CoinData
+    public partial class CoinFullData : CoinData
     {
         [Newtonsoft.Json.JsonProperty("asset_platform_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Asset_platform_id { get; init; }
+        public string Asset_platform_id { get; set; }
 
         [Newtonsoft.Json.JsonProperty("platforms", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Platforms { get; set; }
 
         [Newtonsoft.Json.JsonProperty("block_time_in_minutes", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double Block_time_in_minutes { get; init; }
+        public double Block_time_in_minutes { get; set; }
 
         [Newtonsoft.Json.JsonProperty("hashing_algorithm", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Hashing_algorithm { get; init; }
+        public string Hashing_algorithm { get; set; }
 
         [Newtonsoft.Json.JsonProperty("categories", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Categories { get; init; }
+        public System.Collections.Generic.List<string> Categories { get; set; }
 
         [Newtonsoft.Json.JsonProperty("public_notice", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Public_notice { get; init; }
+        public string Public_notice { get; set; }
 
         [Newtonsoft.Json.JsonProperty("status_updates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<object> Status_updates { get; init; }
+        public System.Collections.Generic.List<object> Status_updates { get; set; }
 
         [Newtonsoft.Json.JsonProperty("tickers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<Tickers> Tickers { get; init; }
+        public System.Collections.Generic.List<Tickers> Tickers { get; set; }
 
         [Newtonsoft.Json.JsonProperty("last_updated", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_updated { get; init; }
+        public object Last_updated { get; set; }
 
         [Newtonsoft.Json.JsonProperty("additional_notices", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Additional_notices { get; init; }
+        public System.Collections.Generic.List<string> Additional_notices { get; set; }
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Description { get; set; }
 
         [Newtonsoft.Json.JsonProperty("links", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Links Links { get; init; }
+        public Links Links { get; set; }
 
         [Newtonsoft.Json.JsonProperty("country_origin", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Country_origin { get; init; }
+        public string Country_origin { get; set; }
 
         [Newtonsoft.Json.JsonProperty("contract_address", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Contract_address { get; init; }
+        public string Contract_address { get; set; }
 
         [Newtonsoft.Json.JsonProperty("genesis_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Genesis_date { get; init; }
+        public string Genesis_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("sentiment_votes_up_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Sentiment_votes_up_percentage { get; init; }
+        public decimal? Sentiment_votes_up_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("sentiment_votes_down_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Sentiment_votes_down_percentage { get; init; }
+        public decimal? Sentiment_votes_down_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ico_data", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Ico_data Ico_data { get; init; }
+        public Ico_data Ico_data { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_rank { get; init; }
+        public decimal? Market_cap_rank { get; set; }
 
         [Newtonsoft.Json.JsonProperty("coingecko_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Coingecko_rank { get; init; }
+        public decimal? Coingecko_rank { get; set; }
 
         [Newtonsoft.Json.JsonProperty("coingecko_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Coingecko_score { get; init; }
+        public decimal Coingecko_score { get; set; }
 
         [Newtonsoft.Json.JsonProperty("developer_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Developer_score { get; init; }
+        public decimal Developer_score { get; set; }
 
         [Newtonsoft.Json.JsonProperty("community_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Community_score { get; init; }
+        public decimal Community_score { get; set; }
 
         [Newtonsoft.Json.JsonProperty("liquidity_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Liquidity_score { get; init; }
+        public decimal Liquidity_score { get; set; }
 
         [Newtonsoft.Json.JsonProperty("public_interest_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Public_interest_score { get; init; }
+        public decimal Public_interest_score { get; set; }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Range
+    public partial class Range
     {
         [Newtonsoft.Json.JsonProperty("prices", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Prices { get; init; }
+        public System.Collections.Generic.List<TimestampedValue> Prices { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_caps", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Market_caps { get; init; }
+        public System.Collections.Generic.List<TimestampedValue> Market_caps { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_volumes", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Total_volumes { get; init; }
+        public System.Collections.Generic.List<TimestampedValue> Total_volumes { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5853,37 +5858,37 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record SearchCoinData
+    public partial class SearchCoinData
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; init; }
+        public string Id { get; set; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; init; }
+        public string Symbol { get; set; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; init; }
+        public string Name { get; set; }
 
         [Newtonsoft.Json.JsonProperty("current_price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Current_price { get; init; }
+        public decimal? Current_price { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap { get; init; }
+        public decimal? Market_cap { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? Market_cap_rank { get; init; }
+        public int? Market_cap_rank { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_volume", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_volume { get; init; }
+        public decimal? Total_volume { get; set; }
 
         [Newtonsoft.Json.JsonProperty("circulating_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Circulating_supply { get; init; }
+        public decimal? Circulating_supply { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_supply { get; init; }
+        public decimal? Total_supply { get; set; }
 
         [Newtonsoft.Json.JsonProperty("max_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Max_supply { get; init; }
+        public decimal? Max_supply { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5897,16 +5902,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Image
+    public partial class Image
     {
         [Newtonsoft.Json.JsonProperty("thumb", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Thumb { get; init; }
+        public string Thumb { get; set; }
 
         [Newtonsoft.Json.JsonProperty("small", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Small { get; init; }
+        public string Small { get; set; }
 
         [Newtonsoft.Json.JsonProperty("large", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Large { get; init; }
+        public string Large { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5920,7 +5925,7 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Market_data
+    public partial class Market_data
     {
         [Newtonsoft.Json.JsonProperty("current_price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Current_price { get; set; }
@@ -5932,7 +5937,7 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Ath_change_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ath_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ath_date { get; init; }
+        public object Ath_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("atl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Atl { get; set; }
@@ -5941,7 +5946,7 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Atl_change_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("atl_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Atl_date { get; init; }
+        public object Atl_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Market_cap { get; set; }
@@ -5989,64 +5994,64 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Market_cap_change_percentage_24h_in_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_supply { get; init; }
+        public decimal? Total_supply { get; set; }
 
         [Newtonsoft.Json.JsonProperty("max_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Max_supply { get; init; }
+        public decimal? Max_supply { get; set; }
 
         [Newtonsoft.Json.JsonProperty("circulating_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Circulating_supply { get; init; }
+        public decimal? Circulating_supply { get; set; }
 
         [Newtonsoft.Json.JsonProperty("last_updated", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_updated { get; init; }
+        public object Last_updated { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_value_locked", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Total_value_locked { get; init; }
+        public object Total_value_locked { get; set; }
 
         [Newtonsoft.Json.JsonProperty("mcap_to_tvl_ratio", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Mcap_to_tvl_ratio { get; init; }
+        public decimal? Mcap_to_tvl_ratio { get; set; }
 
         [Newtonsoft.Json.JsonProperty("fdv_to_tvl_ratio", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Fdv_to_tvl_ratio { get; init; }
+        public decimal? Fdv_to_tvl_ratio { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_rank { get; init; }
+        public decimal? Market_cap_rank { get; set; }
 
         [Newtonsoft.Json.JsonProperty("fully_diluted_valuation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Fully_diluted_valuation { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_24h { get; init; }
+        public decimal? Price_change_24h { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_24h { get; init; }
+        public decimal? Price_change_percentage_24h { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_7d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_7d { get; init; }
+        public decimal? Price_change_percentage_7d { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_14d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_14d { get; init; }
+        public decimal? Price_change_percentage_14d { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_30d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_30d { get; init; }
+        public decimal? Price_change_percentage_30d { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_60d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_60d { get; init; }
+        public decimal? Price_change_percentage_60d { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_200d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_200d { get; init; }
+        public decimal? Price_change_percentage_200d { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_1y", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_1y { get; init; }
+        public decimal? Price_change_percentage_1y { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_change_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_change_24h { get; init; }
+        public decimal? Market_cap_change_24h { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_change_percentage_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_change_percentage_24h { get; init; }
+        public decimal? Market_cap_change_percentage_24h { get; set; }
 
         [Newtonsoft.Json.JsonProperty("roi", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Roi Roi { get; init; }
+        public Roi Roi { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6060,61 +6065,61 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Tickers
+    public partial class Tickers
     {
         [Newtonsoft.Json.JsonProperty("base", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Base { get; init; }
+        public string Base { get; set; }
 
         [Newtonsoft.Json.JsonProperty("target", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Target { get; init; }
+        public string Target { get; set; }
 
         [Newtonsoft.Json.JsonProperty("market", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Market Market { get; init; }
+        public Market Market { get; set; }
 
         [Newtonsoft.Json.JsonProperty("last", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double Last { get; init; }
+        public double Last { get; set; }
 
         [Newtonsoft.Json.JsonProperty("volume", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Volume { get; init; }
+        public decimal Volume { get; set; }
 
         [Newtonsoft.Json.JsonProperty("converted_last", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Converted_last Converted_last { get; init; }
+        public Converted_last Converted_last { get; set; }
 
         [Newtonsoft.Json.JsonProperty("converted_volume", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Converted_volume Converted_volume { get; init; }
+        public Converted_volume Converted_volume { get; set; }
 
         [Newtonsoft.Json.JsonProperty("trust_score", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Trust_score { get; init; }
+        public string Trust_score { get; set; }
 
         [Newtonsoft.Json.JsonProperty("bid_ask_spread_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Bid_ask_spread_percentage { get; init; }
+        public decimal? Bid_ask_spread_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("timestamp", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Timestamp { get; init; }
+        public object Timestamp { get; set; }
 
         [Newtonsoft.Json.JsonProperty("last_traded_at", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_traded_at { get; init; }
+        public object Last_traded_at { get; set; }
 
         [Newtonsoft.Json.JsonProperty("last_fetch_at", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_fetch_at { get; init; }
+        public object Last_fetch_at { get; set; }
 
         [Newtonsoft.Json.JsonProperty("is_anomaly", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Is_anomaly { get; init; }
+        public bool Is_anomaly { get; set; }
 
         [Newtonsoft.Json.JsonProperty("is_stale", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Is_stale { get; init; }
+        public bool Is_stale { get; set; }
 
         [Newtonsoft.Json.JsonProperty("trade_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Trade_url { get; init; }
+        public string Trade_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("token_info_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Token_info_url { get; init; }
+        public string Token_info_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("coin_id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Coin_id { get; init; }
+        public string Coin_id { get; set; }
 
         [Newtonsoft.Json.JsonProperty("target_coin_id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Target_coin_id { get; init; }
+        public string Target_coin_id { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6128,40 +6133,40 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Links
+    public partial class Links
     {
         [Newtonsoft.Json.JsonProperty("homepage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Homepage { get; init; }
+        public System.Collections.Generic.List<string> Homepage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("blockchain_site", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Blockchain_site { get; init; }
+        public System.Collections.Generic.List<string> Blockchain_site { get; set; }
 
         [Newtonsoft.Json.JsonProperty("official_forum_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Official_forum_url { get; init; }
+        public System.Collections.Generic.List<string> Official_forum_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("chat_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Chat_url { get; init; }
+        public System.Collections.Generic.List<string> Chat_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("announcement_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Announcement_url { get; init; }
+        public System.Collections.Generic.List<string> Announcement_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("twitter_screen_name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Twitter_screen_name { get; init; }
+        public string Twitter_screen_name { get; set; }
 
         [Newtonsoft.Json.JsonProperty("facebook_username", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Facebook_username { get; init; }
+        public string Facebook_username { get; set; }
 
         [Newtonsoft.Json.JsonProperty("bitcointalk_thread_identifier", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Bitcointalk_thread_identifier { get; init; }
+        public string Bitcointalk_thread_identifier { get; set; }
 
         [Newtonsoft.Json.JsonProperty("telegram_channel_identifier", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Telegram_channel_identifier { get; init; }
+        public string Telegram_channel_identifier { get; set; }
 
         [Newtonsoft.Json.JsonProperty("subreddit_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Subreddit_url { get; init; }
+        public string Subreddit_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("repos_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Repos_url Repos_url { get; init; }
+        public Repos_url Repos_url { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6175,97 +6180,97 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Ico_data
+    public partial class Ico_data
     {
         [Newtonsoft.Json.JsonProperty("ico_start_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ico_start_date { get; init; }
+        public object Ico_start_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ico_end_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ico_end_date { get; init; }
+        public object Ico_end_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("short_desc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Short_desc { get; init; }
+        public string Short_desc { get; set; }
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Description { get; init; }
+        public string Description { get; set; }
 
         [Newtonsoft.Json.JsonProperty("links", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Links { get; init; }
+        public object Links { get; set; }
 
         [Newtonsoft.Json.JsonProperty("softcap_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Softcap_currency { get; init; }
+        public string Softcap_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("hardcap_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Hardcap_currency { get; init; }
+        public string Hardcap_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_raised_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Total_raised_currency { get; init; }
+        public string Total_raised_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("softcap_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Softcap_amount { get; init; }
+        public object Softcap_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("hardcap_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Hardcap_amount { get; init; }
+        public object Hardcap_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_raised", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Total_raised { get; init; }
+        public object Total_raised { get; set; }
 
         [Newtonsoft.Json.JsonProperty("quote_pre_sale_currency", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Quote_pre_sale_currency { get; init; }
+        public string Quote_pre_sale_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("base_pre_sale_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Base_pre_sale_amount { get; init; }
+        public object Base_pre_sale_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("quote_pre_sale_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Quote_pre_sale_amount { get; init; }
+        public object Quote_pre_sale_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("quote_public_sale_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Quote_public_sale_currency { get; init; }
+        public string Quote_public_sale_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("base_public_sale_amount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Base_public_sale_amount { get; init; }
+        public object Base_public_sale_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("quote_public_sale_amount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Quote_public_sale_amount { get; init; }
+        public object Quote_public_sale_amount { get; set; }
 
         [Newtonsoft.Json.JsonProperty("accepting_currencies", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Accepting_currencies { get; init; }
+        public string Accepting_currencies { get; set; }
 
         [Newtonsoft.Json.JsonProperty("country_origin", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Country_origin { get; init; }
+        public string Country_origin { get; set; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_start_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Pre_sale_start_date { get; init; }
+        public object Pre_sale_start_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_end_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Pre_sale_end_date { get; init; }
+        public object Pre_sale_end_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Whitelist_url { get; init; }
+        public string Whitelist_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_start_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Whitelist_start_date { get; init; }
+        public object Whitelist_start_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_end_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Whitelist_end_date { get; init; }
+        public object Whitelist_end_date { get; set; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_available", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Whitelist_available { get; init; }
+        public string Whitelist_available { get; set; }
 
         [Newtonsoft.Json.JsonProperty("bounty_detail_url", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Bounty_detail_url { get; init; }
+        public string Bounty_detail_url { get; set; }
 
         [Newtonsoft.Json.JsonProperty("amount_for_sale", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Amount_for_sale { get; init; }
+        public decimal? Amount_for_sale { get; set; }
 
         [Newtonsoft.Json.JsonProperty("kyc_required", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Kyc_required { get; init; }
+        public bool Kyc_required { get; set; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_available", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Pre_sale_available { get; init; }
+        public string Pre_sale_available { get; set; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_ended", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Pre_sale_ended { get; init; }
+        public bool Pre_sale_ended { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6279,16 +6284,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Roi
+    public partial class Roi
     {
         [Newtonsoft.Json.JsonProperty("times", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Times { get; init; }
+        public decimal? Times { get; set; }
 
         [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Currency { get; init; }
+        public string Currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Percentage { get; init; }
+        public decimal? Percentage { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6302,16 +6307,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Market
+    public partial class Market
     {
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; init; }
+        public string Name { get; set; }
 
         [Newtonsoft.Json.JsonProperty("identifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Identifier { get; init; }
+        public string Identifier { get; set; }
 
         [Newtonsoft.Json.JsonProperty("has_trading_incentive", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Has_trading_incentive { get; init; }
+        public bool Has_trading_incentive { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6325,16 +6330,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Converted_last
+    public partial class Converted_last
     {
         [Newtonsoft.Json.JsonProperty("btc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Btc { get; init; }
+        public decimal Btc { get; set; }
 
         [Newtonsoft.Json.JsonProperty("eth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Eth { get; init; }
+        public decimal Eth { get; set; }
 
         [Newtonsoft.Json.JsonProperty("usd", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Usd { get; init; }
+        public decimal Usd { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6348,16 +6353,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Converted_volume
+    public partial class Converted_volume
     {
         [Newtonsoft.Json.JsonProperty("btc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Btc { get; init; }
+        public decimal Btc { get; set; }
 
         [Newtonsoft.Json.JsonProperty("eth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Eth { get; init; }
+        public decimal Eth { get; set; }
 
         [Newtonsoft.Json.JsonProperty("usd", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Usd { get; init; }
+        public decimal Usd { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6371,13 +6376,13 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial record Repos_url
+    public partial class Repos_url
     {
         [Newtonsoft.Json.JsonProperty("github", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Github { get; init; }
+        public System.Collections.Generic.List<string> Github { get; set; }
 
         [Newtonsoft.Json.JsonProperty("bitbucket", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Bitbucket { get; init; }
+        public System.Collections.Generic.List<string> Bitbucket { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 

--- a/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ApiClients.cs
@@ -6,6 +6,7 @@
 
 using Trakx.Common.ApiClient;
 
+#pragma warning disable CS0618
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
 #pragma warning disable 472 // Disable "CS0472 The result of the expression is always 'false' since a value of type 'Int32' is never equal to 'null' of type 'Int32?'
@@ -92,7 +93,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -366,7 +367,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -472,7 +473,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -537,7 +538,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -916,7 +917,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1033,7 +1034,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1146,7 +1147,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1252,7 +1253,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1336,7 +1337,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1431,7 +1432,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1522,7 +1523,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1606,7 +1607,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1702,7 +1703,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -1964,7 +1965,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2052,7 +2053,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2145,7 +2146,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2450,7 +2451,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2517,7 +2518,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2593,7 +2594,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2694,7 +2695,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2777,7 +2778,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -2855,7 +2856,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3097,7 +3098,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3185,7 +3186,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3450,7 +3451,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3533,7 +3534,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3600,7 +3601,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3678,7 +3679,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -3937,7 +3938,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4020,7 +4021,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4098,7 +4099,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4165,7 +4166,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4404,7 +4405,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4677,7 +4678,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4744,7 +4745,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -4811,7 +4812,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5025,7 +5026,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5239,7 +5240,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5464,7 +5465,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5531,7 +5532,7 @@ namespace Trakx.CoinGecko.ApiClient
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var response_ = client_.Send(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                     var disposeResponse_ = true;
                     try
                     {
@@ -5679,16 +5680,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class CoinList
+    public partial record CoinList
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; set; }
+        public string Id { get; init; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; set; }
+        public string Symbol { get; init; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5702,34 +5703,34 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class CoinData
+    public partial record CoinData
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; set; }
+        public string Id { get; init; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; set; }
+        public string Symbol { get; init; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         [Newtonsoft.Json.JsonProperty("localization", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Localization { get; set; }
 
         [Newtonsoft.Json.JsonProperty("image", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Image Image { get; set; }
+        public Image Image { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_data", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Market_data Market_data { get; set; }
+        public Market_data Market_data { get; init; }
 
         [Newtonsoft.Json.JsonProperty("community_data", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Community_data { get; set; }
+        public object Community_data { get; init; }
 
         [Newtonsoft.Json.JsonProperty("developer_data", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Developer_data { get; set; }
+        public object Developer_data { get; init; }
 
         [Newtonsoft.Json.JsonProperty("public_interest_stats", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Public_interest_stats { get; set; }
+        public object Public_interest_stats { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5743,96 +5744,96 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class CoinFullData : CoinData
+    public partial record CoinFullData : CoinData
     {
         [Newtonsoft.Json.JsonProperty("asset_platform_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Asset_platform_id { get; set; }
+        public string Asset_platform_id { get; init; }
 
         [Newtonsoft.Json.JsonProperty("platforms", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Platforms { get; set; }
 
         [Newtonsoft.Json.JsonProperty("block_time_in_minutes", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double Block_time_in_minutes { get; set; }
+        public double Block_time_in_minutes { get; init; }
 
         [Newtonsoft.Json.JsonProperty("hashing_algorithm", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Hashing_algorithm { get; set; }
+        public string Hashing_algorithm { get; init; }
 
         [Newtonsoft.Json.JsonProperty("categories", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Categories { get; set; }
+        public System.Collections.Generic.List<string> Categories { get; init; }
 
         [Newtonsoft.Json.JsonProperty("public_notice", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Public_notice { get; set; }
+        public string Public_notice { get; init; }
 
         [Newtonsoft.Json.JsonProperty("status_updates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<object> Status_updates { get; set; }
+        public System.Collections.Generic.List<object> Status_updates { get; init; }
 
         [Newtonsoft.Json.JsonProperty("tickers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<Tickers> Tickers { get; set; }
+        public System.Collections.Generic.List<Tickers> Tickers { get; init; }
 
         [Newtonsoft.Json.JsonProperty("last_updated", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_updated { get; set; }
+        public object Last_updated { get; init; }
 
         [Newtonsoft.Json.JsonProperty("additional_notices", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Additional_notices { get; set; }
+        public System.Collections.Generic.List<string> Additional_notices { get; init; }
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, string> Description { get; set; }
 
         [Newtonsoft.Json.JsonProperty("links", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Links Links { get; set; }
+        public Links Links { get; init; }
 
         [Newtonsoft.Json.JsonProperty("country_origin", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Country_origin { get; set; }
+        public string Country_origin { get; init; }
 
         [Newtonsoft.Json.JsonProperty("contract_address", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Contract_address { get; set; }
+        public string Contract_address { get; init; }
 
         [Newtonsoft.Json.JsonProperty("genesis_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Genesis_date { get; set; }
+        public string Genesis_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("sentiment_votes_up_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Sentiment_votes_up_percentage { get; set; }
+        public decimal? Sentiment_votes_up_percentage { get; init; }
 
         [Newtonsoft.Json.JsonProperty("sentiment_votes_down_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Sentiment_votes_down_percentage { get; set; }
+        public decimal? Sentiment_votes_down_percentage { get; init; }
 
         [Newtonsoft.Json.JsonProperty("ico_data", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Ico_data Ico_data { get; set; }
+        public Ico_data Ico_data { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_rank { get; set; }
+        public decimal? Market_cap_rank { get; init; }
 
         [Newtonsoft.Json.JsonProperty("coingecko_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Coingecko_rank { get; set; }
+        public decimal? Coingecko_rank { get; init; }
 
         [Newtonsoft.Json.JsonProperty("coingecko_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Coingecko_score { get; set; }
+        public decimal Coingecko_score { get; init; }
 
         [Newtonsoft.Json.JsonProperty("developer_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Developer_score { get; set; }
+        public decimal Developer_score { get; init; }
 
         [Newtonsoft.Json.JsonProperty("community_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Community_score { get; set; }
+        public decimal Community_score { get; init; }
 
         [Newtonsoft.Json.JsonProperty("liquidity_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Liquidity_score { get; set; }
+        public decimal Liquidity_score { get; init; }
 
         [Newtonsoft.Json.JsonProperty("public_interest_score", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Public_interest_score { get; set; }
+        public decimal Public_interest_score { get; init; }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Range
+    public partial record Range
     {
         [Newtonsoft.Json.JsonProperty("prices", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Prices { get; set; }
+        public System.Collections.Generic.List<TimestampedValue> Prices { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_caps", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Market_caps { get; set; }
+        public System.Collections.Generic.List<TimestampedValue> Market_caps { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_volumes", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<TimestampedValue> Total_volumes { get; set; }
+        public System.Collections.Generic.List<TimestampedValue> Total_volumes { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5858,37 +5859,37 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class SearchCoinData
+    public partial record SearchCoinData
     {
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; set; }
+        public string Id { get; init; }
 
         [Newtonsoft.Json.JsonProperty("symbol", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Symbol { get; set; }
+        public string Symbol { get; init; }
 
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         [Newtonsoft.Json.JsonProperty("current_price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Current_price { get; set; }
+        public decimal? Current_price { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap { get; set; }
+        public decimal? Market_cap { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? Market_cap_rank { get; set; }
+        public int? Market_cap_rank { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_volume", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_volume { get; set; }
+        public decimal? Total_volume { get; init; }
 
         [Newtonsoft.Json.JsonProperty("circulating_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Circulating_supply { get; set; }
+        public decimal? Circulating_supply { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_supply { get; set; }
+        public decimal? Total_supply { get; init; }
 
         [Newtonsoft.Json.JsonProperty("max_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Max_supply { get; set; }
+        public decimal? Max_supply { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5902,16 +5903,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Image
+    public partial record Image
     {
         [Newtonsoft.Json.JsonProperty("thumb", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Thumb { get; set; }
+        public string Thumb { get; init; }
 
         [Newtonsoft.Json.JsonProperty("small", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Small { get; set; }
+        public string Small { get; init; }
 
         [Newtonsoft.Json.JsonProperty("large", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Large { get; set; }
+        public string Large { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -5925,7 +5926,7 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Market_data
+    public partial record Market_data
     {
         [Newtonsoft.Json.JsonProperty("current_price", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Current_price { get; set; }
@@ -5937,7 +5938,7 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Ath_change_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ath_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ath_date { get; set; }
+        public object Ath_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("atl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Atl { get; set; }
@@ -5946,7 +5947,7 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Atl_change_percentage { get; set; }
 
         [Newtonsoft.Json.JsonProperty("atl_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Atl_date { get; set; }
+        public object Atl_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Market_cap { get; set; }
@@ -5994,64 +5995,64 @@ namespace Trakx.CoinGecko.ApiClient
         public System.Collections.Generic.IDictionary<string, decimal?> Market_cap_change_percentage_24h_in_currency { get; set; }
 
         [Newtonsoft.Json.JsonProperty("total_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Total_supply { get; set; }
+        public decimal? Total_supply { get; init; }
 
         [Newtonsoft.Json.JsonProperty("max_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Max_supply { get; set; }
+        public decimal? Max_supply { get; init; }
 
         [Newtonsoft.Json.JsonProperty("circulating_supply", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Circulating_supply { get; set; }
+        public decimal? Circulating_supply { get; init; }
 
         [Newtonsoft.Json.JsonProperty("last_updated", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_updated { get; set; }
+        public object Last_updated { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_value_locked", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Total_value_locked { get; set; }
+        public object Total_value_locked { get; init; }
 
         [Newtonsoft.Json.JsonProperty("mcap_to_tvl_ratio", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Mcap_to_tvl_ratio { get; set; }
+        public decimal? Mcap_to_tvl_ratio { get; init; }
 
         [Newtonsoft.Json.JsonProperty("fdv_to_tvl_ratio", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Fdv_to_tvl_ratio { get; set; }
+        public decimal? Fdv_to_tvl_ratio { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_rank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_rank { get; set; }
+        public decimal? Market_cap_rank { get; init; }
 
         [Newtonsoft.Json.JsonProperty("fully_diluted_valuation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IDictionary<string, decimal?> Fully_diluted_valuation { get; set; }
 
         [Newtonsoft.Json.JsonProperty("price_change_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_24h { get; set; }
+        public decimal? Price_change_24h { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_24h { get; set; }
+        public decimal? Price_change_percentage_24h { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_7d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_7d { get; set; }
+        public decimal? Price_change_percentage_7d { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_14d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_14d { get; set; }
+        public decimal? Price_change_percentage_14d { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_30d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_30d { get; set; }
+        public decimal? Price_change_percentage_30d { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_60d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_60d { get; set; }
+        public decimal? Price_change_percentage_60d { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_200d", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_200d { get; set; }
+        public decimal? Price_change_percentage_200d { get; init; }
 
         [Newtonsoft.Json.JsonProperty("price_change_percentage_1y", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Price_change_percentage_1y { get; set; }
+        public decimal? Price_change_percentage_1y { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_change_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_change_24h { get; set; }
+        public decimal? Market_cap_change_24h { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market_cap_change_percentage_24h", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Market_cap_change_percentage_24h { get; set; }
+        public decimal? Market_cap_change_percentage_24h { get; init; }
 
         [Newtonsoft.Json.JsonProperty("roi", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Roi Roi { get; set; }
+        public Roi Roi { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6065,61 +6066,61 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Tickers
+    public partial record Tickers
     {
         [Newtonsoft.Json.JsonProperty("base", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Base { get; set; }
+        public string Base { get; init; }
 
         [Newtonsoft.Json.JsonProperty("target", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Target { get; set; }
+        public string Target { get; init; }
 
         [Newtonsoft.Json.JsonProperty("market", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Market Market { get; set; }
+        public Market Market { get; init; }
 
         [Newtonsoft.Json.JsonProperty("last", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double Last { get; set; }
+        public double Last { get; init; }
 
         [Newtonsoft.Json.JsonProperty("volume", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Volume { get; set; }
+        public decimal Volume { get; init; }
 
         [Newtonsoft.Json.JsonProperty("converted_last", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Converted_last Converted_last { get; set; }
+        public Converted_last Converted_last { get; init; }
 
         [Newtonsoft.Json.JsonProperty("converted_volume", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Converted_volume Converted_volume { get; set; }
+        public Converted_volume Converted_volume { get; init; }
 
         [Newtonsoft.Json.JsonProperty("trust_score", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Trust_score { get; set; }
+        public string Trust_score { get; init; }
 
         [Newtonsoft.Json.JsonProperty("bid_ask_spread_percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Bid_ask_spread_percentage { get; set; }
+        public decimal? Bid_ask_spread_percentage { get; init; }
 
         [Newtonsoft.Json.JsonProperty("timestamp", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Timestamp { get; set; }
+        public object Timestamp { get; init; }
 
         [Newtonsoft.Json.JsonProperty("last_traded_at", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_traded_at { get; set; }
+        public object Last_traded_at { get; init; }
 
         [Newtonsoft.Json.JsonProperty("last_fetch_at", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Last_fetch_at { get; set; }
+        public object Last_fetch_at { get; init; }
 
         [Newtonsoft.Json.JsonProperty("is_anomaly", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Is_anomaly { get; set; }
+        public bool Is_anomaly { get; init; }
 
         [Newtonsoft.Json.JsonProperty("is_stale", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Is_stale { get; set; }
+        public bool Is_stale { get; init; }
 
         [Newtonsoft.Json.JsonProperty("trade_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Trade_url { get; set; }
+        public string Trade_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("token_info_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Token_info_url { get; set; }
+        public string Token_info_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("coin_id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Coin_id { get; set; }
+        public string Coin_id { get; init; }
 
         [Newtonsoft.Json.JsonProperty("target_coin_id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Target_coin_id { get; set; }
+        public string Target_coin_id { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6133,40 +6134,40 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Links
+    public partial record Links
     {
         [Newtonsoft.Json.JsonProperty("homepage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Homepage { get; set; }
+        public System.Collections.Generic.List<string> Homepage { get; init; }
 
         [Newtonsoft.Json.JsonProperty("blockchain_site", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Blockchain_site { get; set; }
+        public System.Collections.Generic.List<string> Blockchain_site { get; init; }
 
         [Newtonsoft.Json.JsonProperty("official_forum_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Official_forum_url { get; set; }
+        public System.Collections.Generic.List<string> Official_forum_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("chat_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Chat_url { get; set; }
+        public System.Collections.Generic.List<string> Chat_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("announcement_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Announcement_url { get; set; }
+        public System.Collections.Generic.List<string> Announcement_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("twitter_screen_name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Twitter_screen_name { get; set; }
+        public string Twitter_screen_name { get; init; }
 
         [Newtonsoft.Json.JsonProperty("facebook_username", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Facebook_username { get; set; }
+        public string Facebook_username { get; init; }
 
         [Newtonsoft.Json.JsonProperty("bitcointalk_thread_identifier", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Bitcointalk_thread_identifier { get; set; }
+        public string Bitcointalk_thread_identifier { get; init; }
 
         [Newtonsoft.Json.JsonProperty("telegram_channel_identifier", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Telegram_channel_identifier { get; set; }
+        public string Telegram_channel_identifier { get; init; }
 
         [Newtonsoft.Json.JsonProperty("subreddit_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Subreddit_url { get; set; }
+        public string Subreddit_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("repos_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Repos_url Repos_url { get; set; }
+        public Repos_url Repos_url { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6180,97 +6181,97 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Ico_data
+    public partial record Ico_data
     {
         [Newtonsoft.Json.JsonProperty("ico_start_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ico_start_date { get; set; }
+        public object Ico_start_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("ico_end_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Ico_end_date { get; set; }
+        public object Ico_end_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("short_desc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Short_desc { get; set; }
+        public string Short_desc { get; init; }
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Description { get; set; }
+        public string Description { get; init; }
 
         [Newtonsoft.Json.JsonProperty("links", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Links { get; set; }
+        public object Links { get; init; }
 
         [Newtonsoft.Json.JsonProperty("softcap_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Softcap_currency { get; set; }
+        public string Softcap_currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("hardcap_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Hardcap_currency { get; set; }
+        public string Hardcap_currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_raised_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Total_raised_currency { get; set; }
+        public string Total_raised_currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("softcap_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Softcap_amount { get; set; }
+        public object Softcap_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("hardcap_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Hardcap_amount { get; set; }
+        public object Hardcap_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("total_raised", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Total_raised { get; set; }
+        public object Total_raised { get; init; }
 
         [Newtonsoft.Json.JsonProperty("quote_pre_sale_currency", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Quote_pre_sale_currency { get; set; }
+        public string Quote_pre_sale_currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("base_pre_sale_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Base_pre_sale_amount { get; set; }
+        public object Base_pre_sale_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("quote_pre_sale_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Quote_pre_sale_amount { get; set; }
+        public object Quote_pre_sale_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("quote_public_sale_currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Quote_public_sale_currency { get; set; }
+        public string Quote_public_sale_currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("base_public_sale_amount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Base_public_sale_amount { get; set; }
+        public object Base_public_sale_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("quote_public_sale_amount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Quote_public_sale_amount { get; set; }
+        public object Quote_public_sale_amount { get; init; }
 
         [Newtonsoft.Json.JsonProperty("accepting_currencies", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Accepting_currencies { get; set; }
+        public string Accepting_currencies { get; init; }
 
         [Newtonsoft.Json.JsonProperty("country_origin", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Country_origin { get; set; }
+        public string Country_origin { get; init; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_start_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Pre_sale_start_date { get; set; }
+        public object Pre_sale_start_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_end_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Pre_sale_end_date { get; set; }
+        public object Pre_sale_end_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_url", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Whitelist_url { get; set; }
+        public string Whitelist_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_start_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Whitelist_start_date { get; set; }
+        public object Whitelist_start_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_end_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public object Whitelist_end_date { get; set; }
+        public object Whitelist_end_date { get; init; }
 
         [Newtonsoft.Json.JsonProperty("whitelist_available", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Whitelist_available { get; set; }
+        public string Whitelist_available { get; init; }
 
         [Newtonsoft.Json.JsonProperty("bounty_detail_url", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Bounty_detail_url { get; set; }
+        public string Bounty_detail_url { get; init; }
 
         [Newtonsoft.Json.JsonProperty("amount_for_sale", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Amount_for_sale { get; set; }
+        public decimal? Amount_for_sale { get; init; }
 
         [Newtonsoft.Json.JsonProperty("kyc_required", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Kyc_required { get; set; }
+        public bool Kyc_required { get; init; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_available", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Pre_sale_available { get; set; }
+        public string Pre_sale_available { get; init; }
 
         [Newtonsoft.Json.JsonProperty("pre_sale_ended", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Pre_sale_ended { get; set; }
+        public bool Pre_sale_ended { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6284,16 +6285,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Roi
+    public partial record Roi
     {
         [Newtonsoft.Json.JsonProperty("times", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Times { get; set; }
+        public decimal? Times { get; init; }
 
         [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Currency { get; set; }
+        public string Currency { get; init; }
 
         [Newtonsoft.Json.JsonProperty("percentage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal? Percentage { get; set; }
+        public decimal? Percentage { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6307,16 +6308,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Market
+    public partial record Market
     {
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         [Newtonsoft.Json.JsonProperty("identifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Identifier { get; set; }
+        public string Identifier { get; init; }
 
         [Newtonsoft.Json.JsonProperty("has_trading_incentive", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool Has_trading_incentive { get; set; }
+        public bool Has_trading_incentive { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6330,16 +6331,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Converted_last
+    public partial record Converted_last
     {
         [Newtonsoft.Json.JsonProperty("btc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Btc { get; set; }
+        public decimal Btc { get; init; }
 
         [Newtonsoft.Json.JsonProperty("eth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Eth { get; set; }
+        public decimal Eth { get; init; }
 
         [Newtonsoft.Json.JsonProperty("usd", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Usd { get; set; }
+        public decimal Usd { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6353,16 +6354,16 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Converted_volume
+    public partial record Converted_volume
     {
         [Newtonsoft.Json.JsonProperty("btc", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Btc { get; set; }
+        public decimal Btc { get; init; }
 
         [Newtonsoft.Json.JsonProperty("eth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Eth { get; set; }
+        public decimal Eth { get; init; }
 
         [Newtonsoft.Json.JsonProperty("usd", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public decimal Usd { get; set; }
+        public decimal Usd { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 
@@ -6376,13 +6377,13 @@ namespace Trakx.CoinGecko.ApiClient
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class Repos_url
+    public partial record Repos_url
     {
         [Newtonsoft.Json.JsonProperty("github", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Github { get; set; }
+        public System.Collections.Generic.List<string> Github { get; init; }
 
         [Newtonsoft.Json.JsonProperty("bitbucket", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<string> Bitbucket { get; set; }
+        public System.Collections.Generic.List<string> Bitbucket { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 

--- a/src/Trakx.CoinGecko.ApiClient/CachedHttpClientHandler.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CachedHttpClientHandler.cs
@@ -123,7 +123,12 @@ public class CachedHttpClientHandler : DelegatingHandler
             }
         }
 
-        var key = $"[{request.Method}]{request.RequestUri}|{request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult()}";
+        string? content
+            = request.Content == null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        var key = $"[{request.Method}]{request.RequestUri}|{content}";
 
         var (message, cachedContent) = await _cache.GetOrCreateAsync(key, async e =>
         {

--- a/src/Trakx.CoinGecko.ApiClient/CachedHttpClientHandler.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CachedHttpClientHandler.cs
@@ -82,21 +82,19 @@ public class CachedHttpClientHandler : DelegatingHandler
     /// <param name="request"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-        CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        Guard.Against.Null(request, nameof(request));
+        Guard.Against.Null(request);
 
         return await TryGetOrSetRequestFromCache(request, cancellationToken)
             .ConfigureAwait(false);
     }
 
-    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override HttpResponseMessage Send(
+        HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        Guard.Against.Null(request, nameof(request));
-
-        return TryGetOrSetRequestFromCache(request, cancellationToken)
-            .ConfigureAwait(false).GetAwaiter().GetResult();
+        return SendAsync(request, cancellationToken).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
@@ -231,7 +231,7 @@ public class CoinGeckoClient : ICoinGeckoClient
     public async Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(
         string id, string vsCurrency,
         DateTimeOffset start, DateTimeOffset end,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         var range = await _coinsClient
             .RangeAsync(id, vsCurrency, start.ToUnixTimeSeconds(), end.ToUnixTimeSeconds(), cancellationToken)

--- a/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Trakx.Common.ApiClient;
+using Trakx.CoinGecko.ApiClient.Models;
 using Trakx.Common.Extensions;
 using Trakx.Common.Logging;
 
@@ -17,8 +15,9 @@ namespace Trakx.CoinGecko.ApiClient;
 
 public class CoinGeckoClient : ICoinGeckoClient
 {
-    private static readonly ILogger Logger =
-        LoggerProvider.Create(MethodBase.GetCurrentMethod()!.DeclaringType!);
+    internal const string MainQuoteCurrency = Constants.Usd;
+
+    private static readonly TimeSpan DefaultCacheLifeSpan = TimeSpan.FromDays(1);
 
     private readonly IMemoryCache _cache;
     private readonly ICoinsClient _coinsClient;
@@ -26,15 +25,9 @@ public class CoinGeckoClient : ICoinGeckoClient
     private Dictionary<string, string>? _idsBySymbolName;
     private readonly string? _typeName;
 
-    public Dictionary<string, string> IdsBySymbolName
-    {
-        get
-        {
-            var idsBySymbolName = _idsBySymbolName ??= GetCoinList().GetAwaiter().GetResult()
-                .ToDictionary(c => GetSymbolNameKey(c.Symbol, c.Name), c => c.Id);
-            return idsBySymbolName;
-        }
-    }
+    private static readonly ILogger Logger = LoggerProvider.Create<CoinGeckoClient>();
+
+    public Dictionary<string, string> IdsBySymbolName => _idsBySymbolName ??= GetIdsBySymbolName();
 
     public Dictionary<string, CoinFullData> CoinFullDataByIds { get; }
 
@@ -47,183 +40,221 @@ public class CoinGeckoClient : ICoinGeckoClient
         _coinsClient = coinsClient;
         _simpleClient = simpleClient;
 
-        CoinFullDataByIds = new Dictionary<string, CoinFullData>();
+        CoinFullDataByIds = new();
         _typeName = GetType().FullName;
     }
 
     /// <inheritdoc />
-    public async Task<decimal?> GetLatestPrice(string coinGeckoId, string quoteCurrencyId = "usd-coin")
-    {
-        Guard.Against.NullOrEmpty(quoteCurrencyId, nameof(quoteCurrencyId));
-
-        var tickerDetails = await _simpleClient
-            .PriceAsync($"{coinGeckoId},{quoteCurrencyId}", "usd")
-            .ConfigureAwait(false);
-
-        Logger.LogDebug("Received latest price {tickerDetails}", JsonSerializer.Serialize(tickerDetails));
-
-        var price = tickerDetails.Content[coinGeckoId]["usd"];
-        var conversionToQuoteCurrency = quoteCurrencyId == "usd"
-            ? 1m
-            : tickerDetails.Content[quoteCurrencyId]["usd"];
-
-        return price / conversionToQuoteCurrency ?? 0m;
-    }
-
     public async Task<string?> GetCoinGeckoIdFromSymbol(string symbol)
     {
         var coinList = await GetCoinList();
 
-        var ids = coinList.Where(c =>
-                c.Symbol.Equals(symbol, StringComparison.InvariantCultureIgnoreCase))
+        var ids = coinList
+            .Where(c => c.Symbol.EqualsIgnoreCase(symbol))
             .ToList();
-        return ids.Count == 1 ? ids[0].Id : null;
-    }
 
-    private async Task<decimal> GetUsdFxRate(string quoteCurrencyId, string date)
-    {
-        Guard.Against.NullOrWhiteSpace(quoteCurrencyId, nameof(quoteCurrencyId));
+        if (ids.Count != 1) return null;
 
-        var cacheKey = $"{_typeName}|usd-fx-rate|{quoteCurrencyId}|{date}";
-        if (_cache.TryGetValue(cacheKey, out decimal cached)) return cached;
-
-        var quoteResponse = await _coinsClient.HistoryAsync(quoteCurrencyId, date, false.ToString())
-            .ConfigureAwait(false);
-
-        var fxRate = quoteResponse.Content.Market_data is not null &&
-                     quoteResponse.Content.Market_data.Current_price.ContainsKey(Constants.Usd) ?
-            quoteResponse.Content.Market_data.Current_price[Constants.Usd] : default;
-
-        if (fxRate == null)
-        {
-            Logger.LogDebug($"Current price for '{Constants.Usd}' in coin id '{quoteCurrencyId} for date '{date:dd-MM-yyyy}' is missing.");
-            throw new FailedToRetrievePriceException($"Failed to retrieve price of {quoteCurrencyId} as of {date}");
-        }
-
-        var entry = _cache.CreateEntry(cacheKey);
-        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
-        entry.Value = fxRate.Value;
-        return fxRate.Value;
+        return ids[0].Id;
     }
 
     /// <inheritdoc />
-    public async Task<MarketData?> GetMarketDataAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = "usd-coin")
-    {
-        var date = asOf.ToString("dd-MM-yyyy");
-        var cacheKey = $"{_typeName}|market-data|{id}|{quoteCurrencyId}|{date}";
-        if (_cache.TryGetValue(cacheKey, out MarketData cached)) return cached;
-
-        var fullData = await _coinsClient
-            .HistoryAsync(id, date, false.ToString())
-            .ConfigureAwait(false);
-
-        var fxRate = await GetUsdFxRate(quoteCurrencyId, date);
-
-        if (fullData.Content.Market_data == null)
-            return null;
-
-        var marketData = new MarketData
-        {
-            AsOf = asOf,
-            CoinId = fullData.Content.Id,
-            CoinSymbol = fullData.Content.Symbol,
-            MarketCap = fullData.Content.Market_data.Market_cap[Constants.Usd] / fxRate,
-            Volume = fullData.Content.Market_data.Total_volume[Constants.Usd] / fxRate,
-            Price = fullData.Content.Market_data.Current_price[Constants.Usd] / fxRate,
-            QuoteCurrency = fullData.Content.Symbol
-        };
-
-        var entry = _cache.CreateEntry(cacheKey);
-        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
-        entry.Value = marketData;
-
-        return marketData;
-    }
-
-    private string GetSymbolNameKey(string symbol, string name)
-    {
-        return $"{symbol.ToLower()}|{name.ToLower()}";
-    }
-
-    public async Task<IReadOnlyList<CoinList>> GetCoinList()
+    public async Task<IList<CoinList>> GetCoinList(CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{_typeName}|coin-list";
-        var result = await _cache.GetOrCreateAsync<ReadOnlyCollection<CoinList>>(cacheKey,
-            async e =>
-            {
-                var coinList = await _coinsClient.ListAllAsync().ConfigureAwait(false);
-                e.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
-                return coinList.Content!.AsReadOnly();
-            });
-        return result;
+
+        return await GetFromCacheOrApi(cacheKey, async () =>
+        {
+            var coinList = await _coinsClient
+                .ListAllAsync(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return coinList.Content;
+        });
     }
 
-    public async Task<IDictionary<string, IDictionary<string, decimal?>>> GetAllPrices(IEnumerable<string> ids, string[]? vsCurrencies = null)
+    public async Task<ISet<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default)
     {
-        var coinsPrice = await _simpleClient.PriceAsync(ids.ToCsvList(true, true, quoted: false),
-            (vsCurrencies ?? new[] { Constants.Usd }).ToCsvList(true, true, quoted: false)).ConfigureAwait(false);
-        return coinsPrice.Content;
+        var cacheKey = $"{_typeName}|supported-vs-currencies";
+
+        return await GetFromCacheOrApi(cacheKey, async () =>
+        {
+            var response = await _simpleClient
+                .Supported_vs_currenciesAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var result = new HashSet<string>(response.Content, StringComparer.OrdinalIgnoreCase);
+            return result;
+        });
     }
 
+    /// <summary>
+    /// As of 2023-06-23, CoinGecko does not support USDc as a quote currency.
+    /// <see href="https://api.coingecko.com/api/v3/simple/supported_vs_currencies"/>
+    /// As such, we need to:
+    /// <list type="bullet">
+    /// <item><description>Use USD as the 'vs currency' in the API call</description></item>
+    /// <item><description>Also get the price of the wanted quote currency</description></item>
+    /// <item><description>Convert the prices to the wanted quote currency</description></item>
+    /// </list>
+    /// </summary>
+    public async Task<decimal?> GetLatestPrice(
+        string coinGeckoId,
+        string quoteCurrencyId = Constants.UsdCoin,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.Against.NullOrWhiteSpace(coinGeckoId);
+        Guard.Against.NullOrWhiteSpace(quoteCurrencyId);
+
+        var prices = await GetAllPrices(
+            coinGeckoId.AsSingletonIEnumerable(),
+            quoteCurrencyId.AsSingletonArray(),
+            cancellationToken);
+
+        var price = prices.GetPrice(coinGeckoId, quoteCurrencyId);
+        return price;
+    }
+
+    /// <inheritdoc />
+    public async Task<MultiplePrices> GetAllPrices(
+        IEnumerable<string> ids,
+        string[]? vsCurrencies = default,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.Against.Null(ids);
+
+        var supportedCurrencies = await GetSupportedQuoteCurrencies(cancellationToken);
+
+        (var baseIds, var quoteIds) = GetIdsForPriceQuery(ids, vsCurrencies, supportedCurrencies);
+
+        var response = await _simpleClient
+            .PriceAsync(baseIds, quoteIds, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (Logger.IsEnabled(LogLevel.Debug))
+        {
+            Logger.LogDebug("Received latest price {PriceAsyncResponse}", JsonSerializer.Serialize(response));
+        }
+
+        var prices = new MultiplePrices(response.Content);
+        return prices;
+    }
+
+    /// <inheritdoc />
     public async Task<IList<ExtendedPrice>> GetAllPricesExtended(
         IEnumerable<string> ids,
-        string[]? vsCurrencies = null,
+        string[]? vsCurrencies = default,
         bool includeMarketCap = false,
-        bool include24HrVol = false)
+        bool include24HrVol = false,
+        CancellationToken cancellationToken = default)
     {
-        var currencies = vsCurrencies ?? new[] { Constants.Usd };
+        if (vsCurrencies == null || vsCurrencies.Length == 0)
+        {
+            vsCurrencies = new[] { MainQuoteCurrency };
+        }
+
+        var supportedCurrencies = await GetSupportedQuoteCurrencies(cancellationToken);
+
+        (var baseIds, var quoteIds) = GetIdsForPriceQuery(ids, vsCurrencies, supportedCurrencies);
+
         var coinPrices = await _simpleClient.PriceAsync(
-                ids.ToCsvList(true, true, quoted: false),
-                currencies.ToCsvList(true, true, quoted: false),
+                baseIds, quoteIds,
                 include_market_cap: includeMarketCap.ToString().ToLower(),
-                include_24hr_vol: include24HrVol.ToString().ToLower())
+                include_24hr_vol: include24HrVol.ToString().ToLower(),
+                cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         var result = new List<ExtendedPrice>();
+
         foreach (var coinInfo in coinPrices.Content)
         {
-            foreach (string currency in currencies)
+            foreach (string currency in vsCurrencies)
             {
                 coinInfo.Value.TryGetValue(currency, out var price);
-                if (price.HasValue)
+                if (price == null) continue;
+
+                coinInfo.Value.TryGetValue($"{currency}_market_cap", out var marketCap);
+                coinInfo.Value.TryGetValue($"{currency}_24h_vol", out var dailyVolume);
+
+                var extendedPrice = new ExtendedPrice
                 {
-                    coinInfo.Value.TryGetValue($"{currency}_market_cap", out var marketCap);
-                    coinInfo.Value.TryGetValue($"{currency}_24h_vol", out var dailyVolume);
-                    result.Add(new ExtendedPrice
-                    {
-                        CoinGeckoId = coinInfo.Key,
-                        Currency = currency,
-                        DailyVolume = dailyVolume,
-                        MarketCap = marketCap,
-                        Price = price.Value,
-                    });
-                }
+                    CoinGeckoId = coinInfo.Key,
+                    Currency = currency,
+                    DailyVolume = dailyVolume,
+                    MarketCap = marketCap,
+                    Price = price.Value,
+                };
+
+                result.Add(extendedPrice);
             }
         }
+
         return result;
     }
 
-    public async Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(string id, string vsCurrency, DateTimeOffset start, DateTimeOffset end,
+    /// <inheritdoc />
+    public async Task<MarketData?> GetMarketDataAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin)
+    {
+        var date = asOf.ToString("dd-MM-yyyy");
+        var cacheKey = $"{_typeName}|market-data|{id}|{quoteCurrencyId}|{date}";
+
+        return await GetFromCacheOrApi(cacheKey, async () =>
+        {
+            var fullData = await _coinsClient
+            .HistoryAsync(id, date, false.ToString())
+            .ConfigureAwait(false);
+
+            var content = fullData.Content;
+            var data = content.Market_data;
+            if (data == null) return null;
+
+            var fxRate = await GetUsdFxRate(quoteCurrencyId, date);
+
+            return new MarketData
+            {
+                AsOf = asOf,
+
+                CoinId = content.Id,
+                CoinSymbol = content.Symbol,
+                QuoteCurrency = content.Symbol,
+
+                MarketCap = data.Market_cap[MainQuoteCurrency] / fxRate,
+                Volume = data.Total_volume[MainQuoteCurrency] / fxRate,
+                Price = data.Current_price[MainQuoteCurrency] / fxRate,
+            };
+        });
+    }
+
+    public async Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(
+        string id, string vsCurrency,
+        DateTimeOffset start, DateTimeOffset end,
         CancellationToken cancellationToken)
     {
         var range = await _coinsClient
             .RangeAsync(id, vsCurrency, start.ToUnixTimeSeconds(), end.ToUnixTimeSeconds(), cancellationToken)
             .ConfigureAwait(false);
 
-        return BuildMarketData(id, vsCurrency, range);
+        return BuildMarketData(id, vsCurrency, range.Content);
     }
 
-    public async Task<IDictionary<DateTimeOffset, MarketData>> GetMarketData(string id, string vsCurrency, int days,
-        CancellationToken cancellationToken)
+    public async Task<IDictionary<DateTimeOffset, MarketData>> GetMarketData(
+        string id, string vsCurrency, int days, CancellationToken cancellationToken = default)
     {
         var range = await _coinsClient
             .Market_chartAsync(id, vsCurrency, days.ToString(), "daily", cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return BuildMarketData(id, vsCurrency, range);
+        return BuildMarketData(id, vsCurrency, range.Content);
     }
 
-    public async Task<List<MarketData>> Search(string vsCurrency, string? ids = null, string? category = null, string? order = null, int? per_page = null, int? page = null, CancellationToken cancellationToken = default)
+    public async Task<List<MarketData>> Search(
+        string vsCurrency,
+        string? ids = null,
+        string? category = null,
+        string? order = null,
+        int? per_page = null,
+        int? page = null,
+        CancellationToken cancellationToken = default)
     {
         var result = await _coinsClient
             .MarketsAsync(vsCurrency, ids, category, order, per_page, page, cancellationToken: cancellationToken)
@@ -242,24 +273,103 @@ public class CoinGeckoClient : ICoinGeckoClient
         });
     }
 
-    #region [ Private methods ]
-
-    private Dictionary<DateTimeOffset, MarketData> BuildMarketData(string id, string vsCurrency, Response<Range> range)
+    private static string GetSymbolNameKey(string symbol, string name)
     {
-        return Enumerable.Range(0, range.Content.Prices.Count).Select(i =>
-                new { Index = i, Date = DateTimeOffset.FromUnixTimeMilliseconds((long)range.Content.Prices[i][0]) })
+        return $"{symbol}|{name}".ToLower();
+    }
+
+    private static Dictionary<DateTimeOffset, MarketData> BuildMarketData(string id, string vsCurrency, Range range)
+    {
+        return Enumerable
+            .Range(0, range.Prices.Count)
+            .Select(i => new { Index = i, Date = DateTimeOffset.FromUnixTimeMilliseconds((long)range.Prices[i][0]) })
             .ToDictionary(d => d.Date,
                 d => new MarketData
                 {
                     AsOf = d.Date,
                     CoinId = id,
                     CoinSymbol = null,
-                    MarketCap = (decimal)range.Content.Market_caps[d.Index][1],
-                    Price = (decimal)range.Content.Prices[d.Index][1],
-                    Volume = (decimal)range.Content.Total_volumes[d.Index][1],
+                    MarketCap = (decimal)range.Market_caps[d.Index][1],
+                    Price = (decimal)range.Prices[d.Index][1],
+                    Volume = (decimal)range.Total_volumes[d.Index][1],
                     QuoteCurrency = vsCurrency
                 });
     }
 
-    #endregion [ Private methods ]
+    private async Task<decimal> GetUsdFxRate(string quoteCurrencyId, string date)
+    {
+        Guard.Against.NullOrWhiteSpace(quoteCurrencyId);
+
+        var cacheKey = $"{_typeName}|usd-fx-rate|{quoteCurrencyId}|{date}";
+
+        return await GetFromCacheOrApi(cacheKey, async () =>
+        {
+            var quoteResponse = await _coinsClient
+                .HistoryAsync(quoteCurrencyId, date, false.ToString())
+                .ConfigureAwait(false);
+
+            decimal? fxRate = null;
+            var currentPrice = quoteResponse.Content.Market_data?.Current_price;
+            currentPrice?.TryGetValue(MainQuoteCurrency, out fxRate);
+
+            if (fxRate != null) return fxRate.Value;
+
+            Logger.LogDebug($"Current price for '{MainQuoteCurrency}' in coin id '{quoteCurrencyId} for date '{date:dd-MM-yyyy}' is missing.");
+            throw new FailedToRetrievePriceException($"Failed to retrieve price of {quoteCurrencyId} as of {date}");
+        });
+    }
+
+    private async Task<T> GetFromCacheOrApi<T>(string cacheKey, Func<Task<T>> getFromApi)
+    {
+        var value = await _cache.GetOrCreateAsync<T>(cacheKey, async (entry) =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = DefaultCacheLifeSpan;
+            return await getFromApi();
+        });
+
+        return value!;
+    }
+
+    private Dictionary<string, string> GetIdsBySymbolName()
+    {
+        return GetCoinList()
+            .GetAwaiter()
+            .GetResult()
+            .ToDictionary(c => GetSymbolNameKey(c.Symbol, c.Name), c => c.Id);
+    }
+
+    /// <summary>
+    /// Each requested quote currency needs to be either a 'base' or a 'vs' id in the price call,
+    /// depending if it's a supported quote currency or not.<br />
+    /// This method ensures a valid list of 'base' and 'vs' ids
+    /// according to the logic explained in the comment for <see cref="GetLatestPrice(string, string)"/>
+    /// </summary>
+    private static (string BaseIds, string QuoteIds) GetIdsForPriceQuery(
+        IEnumerable<string> ids, string[]? vsCurrencies,
+        ISet<string> supportedQuoteCurrencies)
+    {
+        List<string> baseIds = new();
+        List<string> quoteIds = new();
+
+        if (ids != null) baseIds.AddRange(ids);
+
+        vsCurrencies ??= Array.Empty<string>();
+
+        foreach (var id in vsCurrencies)
+        {
+            var isSupported = supportedQuoteCurrencies.Contains(id);
+            if (isSupported) quoteIds.Add(id);
+            else baseIds.Add(id);
+        }
+
+        // ensure at least one supported quote currency
+        if (quoteIds.Count == 0)
+        {
+            quoteIds.Add(MainQuoteCurrency);
+        }
+
+        var baseList = baseIds.ToCsvList(distinct: true, toLower: true, quoted: false);
+        var quoteList = quoteIds.ToCsvList(distinct: true, toLower: true, quoted: false);
+        return (baseList, quoteList);
+    }
 }

--- a/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
@@ -314,7 +314,10 @@ public class CoinGeckoClient : ICoinGeckoClient
 
             if (fxRate != null) return fxRate.Value;
 
-            Logger.LogDebug($"Current price for '{MainQuoteCurrency}' in coin id '{quoteCurrencyId} for date '{date:dd-MM-yyyy}' is missing.");
+            Logger.LogDebug(
+                "Current price for '{quoteCrrency}' in coin id '{quoteCurrencyId} for date '{date:dd-MM-yyyy}' is missing.",
+                MainQuoteCurrency, quoteCurrencyId, date);
+
             throw new FailedToRetrievePriceException($"Failed to retrieve price of {quoteCurrencyId} as of {date}");
         });
     }

--- a/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/CoinGeckoClient.cs
@@ -73,7 +73,7 @@ public class CoinGeckoClient : ICoinGeckoClient
         });
     }
 
-    public async Task<ISet<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default)
+    public async Task<ICollection<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{_typeName}|supported-vs-currencies";
 
@@ -159,8 +159,8 @@ public class CoinGeckoClient : ICoinGeckoClient
 
         var coinPrices = await _simpleClient.PriceAsync(
                 baseIds, quoteIds,
-                include_market_cap: includeMarketCap.ToString().ToLower(),
-                include_24hr_vol: include24HrVol.ToString().ToLower(),
+                include_market_cap: includeMarketCap,
+                include_24hr_vol: include24HrVol,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
@@ -201,7 +201,7 @@ public class CoinGeckoClient : ICoinGeckoClient
         return await GetFromCacheOrApi(cacheKey, async () =>
         {
             var fullData = await _coinsClient
-            .HistoryAsync(id, date, false.ToString())
+            .HistoryAsync(id, date, localization: false)
             .ConfigureAwait(false);
 
             var content = fullData.Content;
@@ -275,7 +275,7 @@ public class CoinGeckoClient : ICoinGeckoClient
 
     private static string GetSymbolNameKey(string symbol, string name)
     {
-        return $"{symbol}|{name}".ToLower();
+        return $"{symbol}|{name}".ToLowerInvariant();
     }
 
     private static Dictionary<DateTimeOffset, MarketData> BuildMarketData(string id, string vsCurrency, Range range)
@@ -305,7 +305,7 @@ public class CoinGeckoClient : ICoinGeckoClient
         return await GetFromCacheOrApi(cacheKey, async () =>
         {
             var quoteResponse = await _coinsClient
-                .HistoryAsync(quoteCurrencyId, date, false.ToString())
+                .HistoryAsync(quoteCurrencyId, date, localization: false)
                 .ConfigureAwait(false);
 
             decimal? fxRate = null;
@@ -349,7 +349,7 @@ public class CoinGeckoClient : ICoinGeckoClient
     /// </summary>
     private static (string BaseIds, string QuoteIds) GetIdsForPriceQuery(
         IEnumerable<string> ids, string[]? vsCurrencies,
-        ISet<string> supportedQuoteCurrencies)
+        ICollection<string> supportedQuoteCurrencies)
     {
         List<string> baseIds = new();
         List<string> quoteIds = new();

--- a/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
@@ -54,7 +54,7 @@ public interface ICoinGeckoClient
     Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(
         string id, string vsCurrency,
         DateTimeOffset start, DateTimeOffset end,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
     Task<List<MarketData>> Search(
         string vsCurrency,

--- a/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
@@ -14,7 +14,7 @@ public interface ICoinGeckoClient
 
     Task<IList<CoinList>> GetCoinList(CancellationToken cancellationToken = default);
 
-    Task<ISet<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default);
+    Task<ICollection<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default);
 
 
     // price operations

--- a/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
+++ b/src/Trakx.CoinGecko.ApiClient/ICoinGeckoClient.cs
@@ -2,19 +2,66 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Trakx.CoinGecko.ApiClient.Models;
 
 namespace Trakx.CoinGecko.ApiClient;
 
 public interface ICoinGeckoClient
 {
-    Task<decimal?> GetLatestPrice(string coinGeckoId, string quoteCurrencyId = Constants.UsdCoin);
-    Task<MarketData?> GetMarketDataAsOfFromId(string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin);
+    // symbol operations
+
     Task<string?> GetCoinGeckoIdFromSymbol(string symbol);
-    Task<IReadOnlyList<CoinList>> GetCoinList();
-    Task<IDictionary<string, IDictionary<string, decimal?>>> GetAllPrices(IEnumerable<string> ids, string[]? vsCurrencies = null);
-    Task<IList<ExtendedPrice>> GetAllPricesExtended(IEnumerable<string> ids, string[]? vsCurrencies = null, bool includeMarketCap = false, bool include24HrVol = false);
-    Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(string id, string vsCurrency,
-        DateTimeOffset start, DateTimeOffset end, CancellationToken cancellationToken);
-    Task<IDictionary<DateTimeOffset, MarketData>> GetMarketData(string id, string vsCurrency, int days, CancellationToken cancellationToken);
-    Task<List<MarketData>> Search(string vsCurrency, string? ids = null, string? category = null, string? order = null, int? per_page = null, int? page = null, CancellationToken cancellationToken = default);
+
+    Task<IList<CoinList>> GetCoinList(CancellationToken cancellationToken = default);
+
+    Task<ISet<string>> GetSupportedQuoteCurrencies(CancellationToken cancellationToken = default);
+
+
+    // price operations
+
+    Task<decimal?> GetLatestPrice(
+        string coinGeckoId,
+        string quoteCurrencyId = Constants.UsdCoin,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a collection of prices,
+    /// grouped by each CoinGecko ID in <paramref name="ids"/>,
+    /// then by each requested <paramref name="vsCurrencies"/>.
+    /// </summary>
+    Task<MultiplePrices> GetAllPrices(
+        IEnumerable<string> ids,
+        string[]? vsCurrencies = default,
+        CancellationToken cancellationToken = default);
+
+    Task<IList<ExtendedPrice>> GetAllPricesExtended(
+        IEnumerable<string> ids,
+        string[]? vsCurrencies = default,
+        bool includeMarketCap = false,
+        bool include24HrVol = false,
+        CancellationToken cancellationToken = default);
+
+
+    // market data
+
+    Task<MarketData?> GetMarketDataAsOfFromId(
+        string id, DateTime asOf, string quoteCurrencyId = Constants.UsdCoin);
+
+    Task<IDictionary<DateTimeOffset, MarketData>> GetMarketData(
+        string id, string vsCurrency, int days,
+        CancellationToken cancellationToken = default);
+
+    Task<IDictionary<DateTimeOffset, MarketData>> GetMarketDataForDateRange(
+        string id, string vsCurrency,
+        DateTimeOffset start, DateTimeOffset end,
+        CancellationToken cancellationToken);
+
+    Task<List<MarketData>> Search(
+        string vsCurrency,
+        string? ids = null,
+        string? category = null,
+        string? order = null,
+        int? per_page = null,
+        int? page = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
@@ -19,7 +19,9 @@ public class MultiplePrices
         var directPrice = TryGetPrice(coinGeckoId, quoteCurrencyId);
         if (directPrice != default) return directPrice;
 
-        foreach (var supportedQuote in _source.Keys)
+        var supportedQuotes = _source.Values.SelectMany(p => p.Keys).Distinct();
+
+        foreach (var supportedQuote in supportedQuotes)
         {
             var conversionRate = TryGetPrice(quoteCurrencyId, supportedQuote);
             if (conversionRate == default) continue;
@@ -36,10 +38,10 @@ public class MultiplePrices
 
     private decimal TryGetPrice(string coinGeckoId, string quoteCurrencyId)
     {
-        _source.TryGetValue(coinGeckoId, out var prices);
-        if (prices == null) return default;
+        _source.TryGetValue(coinGeckoId, out var pricesForSymbol);
+        if (pricesForSymbol == null) return default;
 
-        prices.TryGetValue(quoteCurrencyId, out var price);
+        pricesForSymbol.TryGetValue(quoteCurrencyId, out var price);
         return price.GetValueOrDefault();
     }
 }

--- a/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Trakx.CoinGecko.ApiClient.Models;
+
+public class MultiplePrices
+{
+    private readonly IDictionary<string, IDictionary<string, decimal?>> _source;
+    private readonly string[] _quoteCurrencies;
+
+    public MultiplePrices(IDictionary<string, IDictionary<string, decimal?>> source)
+    {
+        _source = source;
+        _quoteCurrencies = _source.Values.SelectMany(p => p.Keys).Distinct().ToArray();
+    }
+
+    public int TotalPriceCount => _source.Sum(p => p.Value.Count);
+
+    public decimal GetPrice(string coinGeckoId, string quoteCurrencyId = Constants.Usd)
+    {
+        var directPrice = TryGetPrice(coinGeckoId, quoteCurrencyId);
+        if (directPrice != default) return directPrice;
+
+        foreach (var supportedQuote in _quoteCurrencies)
+        {
+            var conversionRate = TryGetPrice(quoteCurrencyId, supportedQuote);
+            if (conversionRate == default) continue;
+
+            var supportedPrice = TryGetPrice(coinGeckoId, supportedQuote);
+            if (supportedPrice == default) continue;
+
+            var convertedPrice = supportedPrice / conversionRate;
+            return convertedPrice;
+        }
+
+        return default;
+    }
+
+    private decimal TryGetPrice(string coinGeckoId, string quoteCurrencyId)
+    {
+        _source.TryGetValue(coinGeckoId, out var prices);
+        if (prices == null) return default;
+
+        prices.TryGetValue(quoteCurrencyId, out var price);
+        return price.GetValueOrDefault();
+    }
+}

--- a/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Models/MultiplePrices.cs
@@ -6,12 +6,10 @@ namespace Trakx.CoinGecko.ApiClient.Models;
 public class MultiplePrices
 {
     private readonly IDictionary<string, IDictionary<string, decimal?>> _source;
-    private readonly string[] _quoteCurrencies;
 
     public MultiplePrices(IDictionary<string, IDictionary<string, decimal?>> source)
     {
         _source = source;
-        _quoteCurrencies = _source.Values.SelectMany(p => p.Keys).Distinct().ToArray();
     }
 
     public int TotalPriceCount => _source.Sum(p => p.Value.Count);
@@ -21,7 +19,7 @@ public class MultiplePrices
         var directPrice = TryGetPrice(coinGeckoId, quoteCurrencyId);
         if (directPrice != default) return directPrice;
 
-        foreach (var supportedQuote in _quoteCurrencies)
+        foreach (var supportedQuote in _source.Keys)
         {
             var conversionRate = TryGetPrice(quoteCurrencyId, supportedQuote);
             if (conversionRate == default) continue;

--- a/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
+++ b/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
@@ -30,8 +30,6 @@
       </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     

--- a/src/Trakx.CoinGecko.ApiClient/openApi3.yaml
+++ b/src/Trakx.CoinGecko.ApiClient/openApi3.yaml
@@ -131,7 +131,12 @@ paths:
       responses:
         200:
           description: list of supported_vs_currencies
-          content: {}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
   /coins/list:
     get:
       tags:

--- a/src/Trakx.CoinGecko.ApiClient/openApi3.yaml
+++ b/src/Trakx.CoinGecko.ApiClient/openApi3.yaml
@@ -44,23 +44,26 @@ paths:
         in: query
         description: '<b>true/false</b> to include market_cap, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_24hr_vol
         in: query
         description: '<b>true/false</b> to include 24hr_vol, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_24hr_change
         in: query
         description: '<b>true/false</b> to include 24hr_change, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_last_updated_at
         in: query
-        description: '<b>true/false</b> to include last_updated_at of price, <b>default:
-          false</b>'
+        description: '<b>true/false</b> to include last_updated_at of price, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       responses:
         200:
           description: List all coins with id, name, and symbol
@@ -102,23 +105,26 @@ paths:
         in: query
         description: '<b>true/false</b> to include market_cap, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_24hr_vol
         in: query
         description: '<b>true/false</b> to include 24hr_vol, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_24hr_change
         in: query
         description: '<b>true/false</b> to include 24hr_change, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       - name: include_last_updated_at
         in: query
-        description: '<b>true/false</b> to include last_updated_at of price, <b>default:
-          false</b>'
+        description: '<b>true/false</b> to include last_updated_at of price, <b>default: false</b>'
         schema:
-          type: string
+          type: boolean
+          default: false
       responses:
         200:
           description: price(s) of cryptocurrency
@@ -150,6 +156,7 @@ paths:
           \ Ethereum based tokens). \n valid values: true, false"
         schema:
           type: boolean
+          default: false
       responses:
         200:
           description: List all coins with id, name, and symbol
@@ -253,36 +260,40 @@ paths:
           type: string
       - name: localization
         in: query
-        description: 'Include all localized languages in response (true/false) <b>[default:
-          true]</b>'
+        description: 'Include all localized languages in response (true/false) <b>[default: true]</b>'
         schema:
-          type: string
+          type: boolean
+          default: true
       - name: tickers
         in: query
         description: 'Include tickers data (true/false) <b>[default: true]</b>'
         schema:
           type: boolean
+          default: true
       - name: market_data
         in: query
         description: 'Include market_data (true/false) <b>[default: true]</b>'
         schema:
           type: boolean
+          default: true
       - name: community_data
         in: query
         description: 'Include community_data data (true/false) <b>[default: true]</b>'
         schema:
           type: boolean
+          default: true
       - name: developer_data
         in: query
         description: 'Include developer_data data (true/false) <b>[default: true]</b>'
         schema:
           type: boolean
+          default: true
       - name: sparkline
         in: query
-        description: 'Include sparkline 7 days data (eg. true, false) <b>[default:
-          false]</b>'
+        description: 'Include sparkline 7 days data (eg. true, false) <b>[default: false]</b>'
         schema:
           type: boolean
+          default: false
       responses:
         200:
           description: Get current data for a coin
@@ -324,15 +335,14 @@ paths:
           type: integer
       - name: order
         in: query
-        description: 'valid values: <b>trust_score_desc (default), trust_score_asc
-          and volume_desc</b>'
+        description: 'valid values: <b>trust_score_desc (default), trust_score_asc and volume_desc</b>'
         schema:
           type: string
       - name: depth
         in: query
         description: 'flag to show 2% orderbook depth. valid values: true, false'
         schema:
-          type: string
+          type: boolean
       responses:
         200:
           description: Get coin tickers
@@ -341,10 +351,8 @@ paths:
     get:
       tags:
       - coins
-      summary: Get historical data (name, price, market, stats) at a given date for
-        a coin
-      description: |
-        Get historical data (name, price, market, stats) at a given date for a coin
+      summary: Get historical data (name, price, market, stats) at a given date for a coin
+      description: Get historical data (name, price, market, stats) at a given date for a coin
       parameters:
       - name: id
         in: path
@@ -362,7 +370,7 @@ paths:
         in: query
         description: Set to false to exclude localized languages in response
         schema:
-          type: string
+          type: boolean
       responses:
         200:
           description: Get historical data at a given date for a coin
@@ -1069,10 +1077,10 @@ paths:
           type: string
       - name: upcoming_events_only
         in: query
-        description: lists only upcoming events. <br>true, false</br> (defaults to
-          true, set to false to list all events)
+        description: lists only upcoming events. <br>true, false</br> (defaults to true, set to false to list all events)
         schema:
-          type: string
+          type: boolean
+          default: true
       - name: from_date
         in: query
         description: lists events after this date yyyy-mm-dd
@@ -1080,8 +1088,7 @@ paths:
           type: string
       - name: to_date
         in: query
-        description: lists events before this date yyyy-mm-dd (set upcoming_events_only
-          to false if fetching past events)
+        description: lists events before this date yyyy-mm-dd (set upcoming_events_only to false if fetching past events)
         schema:
           type: string
       responses:


### PR DESCRIPTION
We are able to get the price for any symbol in a supported quote currency:

<https://api.coingecko.com/api/v3/simple/supported_vs_currencies>

The `GetLatestPrice` method already provided a way to get a price against any other symbol, by loading the wanted quote currency as another base currency, then do a conversion.

This PR expands that feature by ensuring that any requested quote symbol that is not supported is instead added to the list of base ids. Then, all prices are saved in a new class `MultiplePrices`, where the conversion is applied if necessary.

Full support was added to the `supported_vs_currencies` endpoint, caching the information for a day.

Speaking of cache, the "get from cache or API" logic was refactored into `GetFromCacheOrApi`, which in turn uses `_cache.GetOrCreateAsync`

Finally, we had some parameters as `string` that are really `bool` so that was corrected.