### PR TITLE
removed token from integration test list

### DIFF
--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTests.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTests.cs
@@ -256,7 +256,6 @@ public class CoinGeckoClientTests : CoinGeckoClientTestBase
         "compound-ether",
         "compound-governance-token",
         "compound-usd-coin",
-        "compound-usdt",
         "conflux-token",
         "constellation-labs",
         "convex-crv",


### PR DESCRIPTION
removed `compound-usdt` from the integration test, the coingecko API no longer returns data regarding that token