### PR TITLE
Custom logger to reduce spam in logs

### DIFF
--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoApiFixture.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoApiFixture.cs
@@ -21,7 +21,10 @@ public class ApiTestCollection : ICollectionFixture<CoinGeckoApiFixture>
 
 public class CoinGeckoApiFixture : IDisposable
 {
-    public ServiceProvider ServiceProvider { get; }
+    private ServiceProvider? _serviceProvider;
+    public ServiceProvider ServiceProvider => _serviceProvider ??= ServiceCollection.BuildServiceProvider();
+
+    public ServiceCollection ServiceCollection { get; }
 
     public CoinGeckoApiFixture()
     {
@@ -30,11 +33,9 @@ public class CoinGeckoApiFixture : IDisposable
         var apiConfiguration = configurationRoot.GetConfiguration<CoinGeckoApiConfiguration>();
         var cacheConfiguration = configurationRoot.GetConfiguration<RedisCacheConfiguration>();
 
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddCoinGeckoClient(apiConfiguration, cacheConfiguration);
-        SetupMemoryDistributedCache(serviceCollection);
-
-        ServiceProvider = serviceCollection.BuildServiceProvider();
+        ServiceCollection = new ServiceCollection();
+        ServiceCollection.AddCoinGeckoClient(apiConfiguration, cacheConfiguration);
+        SetupMemoryDistributedCache(ServiceCollection);
     }
 
     private static void SetupMemoryDistributedCache(ServiceCollection serviceCollection)

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTestBase.cs
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Integration/CoinGeckoClientTestBase.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Serilog;
 using Sprache;
+using Trakx.Common.Testing.Logging;
 
 namespace Trakx.CoinGecko.ApiClient.Tests.Integration;
 
@@ -18,10 +18,9 @@ public class CoinGeckoClientTestBase
 
     protected CoinGeckoClientTestBase(CoinGeckoApiFixture apiFixture, ITestOutputHelper output)
     {
-        Logger = new LoggerConfiguration()
-            .WriteTo.TestOutput(output)
-            .CreateLogger()
-            .ForContext(MethodBase.GetCurrentMethod()!.DeclaringType!);
+        Logger = output.SetupLoggingAndGetDefaultLogger();
+
+        apiFixture.ServiceCollection.SetupTestLoggerProvider(builder => builder.AddXUnit(output));
 
         ServiceProvider = apiFixture.ServiceProvider;
     }

--- a/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
+++ b/src/Trakx.CoinGecko.ApiClient.Tests/Trakx.CoinGecko.ApiClient.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Trakx.CoinGecko.ApiClient/Clients/ClientConfigurator.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Clients/ClientConfigurator.cs
@@ -15,7 +15,7 @@ public class ClientConfigurator
 
     internal void ApplyConfiguration(HttpClient client)
     {
-        if (Configuration.IsPro)
+        if (Configuration.IsPro && !client.DefaultRequestHeaders.Contains(ProHeader))
             client.DefaultRequestHeaders.Add(ProHeader, Configuration.ApiKey);
 
         if (Configuration.Timeout != default)

--- a/src/Trakx.CoinGecko.ApiClient/Configuration/ApiClientExtensions.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Configuration/ApiClientExtensions.cs
@@ -85,7 +85,7 @@ public static partial class ApiClientExtensions
 
         var clientType = typeof(TImplementation);
 
-        services
+        var httpClientBuilder = services
             .AddHttpClient<TInterface, TImplementation>(clientType.FullName!, configurator.ApplyConfiguration)
             .AddHttpMessageHandler<CachedHttpClientHandler>()
             .AddPolicyHandler((serviceProvider, _) =>
@@ -108,6 +108,14 @@ public static partial class ApiClientExtensions
                     })
                 .WithPolicyKey(clientType.FullName);
             });
+
+        httpClientBuilder.RemoveAllLoggers();
+        httpClientBuilder.AddLogger(s =>
+        {
+            var innerLogger = s.GetRequiredService<ILogger<HttpClientLogger>>();
+            return new HttpClientLogger(innerLogger);
+        });
+
 
         return services;
     }

--- a/src/Trakx.CoinGecko.ApiClient/HttpClientLogger.cs
+++ b/src/Trakx.CoinGecko.ApiClient/HttpClientLogger.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.Extensions.Http.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Trakx.CoinGecko.ApiClient;
+
+public class HttpClientLogger : IHttpClientLogger
+{
+    private readonly ILogger<HttpClientLogger> _logger;
+
+    public HttpClientLogger(ILogger<HttpClientLogger> logger)
+    {
+        _logger = logger;
+    }
+
+    public object? LogRequestStart(HttpRequestMessage request)
+    {
+        _logger.LogInformation(
+            "{Request.Method} {Request.Host}{Request.Path}",
+            request.Method,
+            request.RequestUri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped),
+            request.RequestUri!.PathAndQuery);
+
+        return null;
+    }
+
+    public void LogRequestStop(
+        object? context,
+        HttpRequestMessage request,
+        HttpResponseMessage response,
+        TimeSpan elapsed)
+    {
+        // don't log 200 OK
+        if (response.StatusCode == System.Net.HttpStatusCode.OK) return;
+
+        _logger.LogInformation(
+            "Received '{Response.StatusCodeInt} {Response.StatusCodeString}' after {Response.ElapsedMilliseconds}ms",
+            (int)response.StatusCode,
+            response.StatusCode,
+            elapsed.TotalMilliseconds);
+    }
+
+    public void LogRequestFailed(
+        object? context,
+        HttpRequestMessage request,
+        HttpResponseMessage? response,
+        Exception exception,
+        TimeSpan elapsed)
+    {
+        _logger.LogError(
+            exception,
+            "Request '{Request.Host}{Request.Path}' failed after {Response.ElapsedMilliseconds}ms",
+            request.RequestUri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped),
+            request.RequestUri!.PathAndQuery,
+            elapsed.TotalMilliseconds);
+    }
+}


### PR DESCRIPTION
Currently, each API call to CoinGecko generates 4 log entries:

![image](https://github.com/trakx/coingecko-api-client/assets/161576/e6aa69e2-9c57-470a-8603-4424528bdecc)

This PR removes all the default HttpClient loggers and injects a custom one, so we can log the URL once per call (and don't log the 200 OK response, that's implied).