### PR TITLE
More AWS config, set `CacheDuration` only if it's positive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "NSwag.MSBuild"
+        update-types: [ "version-update:semver-patch" ]
+      - dependency-name: "NSwag.ApiDescription.Client"
+        update-types: [ "version-update:semver-patch" ]
     groups:
       trakx-nuget: # group name
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "NSwag.MSBuild"
-        update-types: [ "version-update:semver-patch" ]
       - dependency-name: "NSwag.ApiDescription.Client"
         update-types: [ "version-update:semver-patch" ]
     groups:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ In order to be able to run some integration tests you should ensure that you hav
 ```awsParams
 # REPOSITORY SECRETS
 /[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/ApiKey
+/[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/BaseUrl
+/[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/CacheDuration
 /[environment]/Trakx/CoinGecko/ApiClient/RedisCacheConfiguration/ConnectionString
 
 # GLOBAL SECRETS
 # Instead of creating a specific repository secret, can use the global one with the same [Key]
 /[environment]/Global/CoinGeckoApiConfiguration/ApiKey
+/[environment]/Global/CoinGeckoApiConfiguration/BaseUrl
+/[environment]/Global/CoinGeckoApiConfiguration/CacheDuration
 /[environment]/Global/RedisCacheConfiguration/ConnectionString
 ```

--- a/README.md
+++ b/README.md
@@ -24,13 +24,11 @@ In order to be able to run some integration tests you should ensure that you hav
 # REPOSITORY SECRETS
 /[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/ApiKey
 /[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/BaseUrl
-/[environment]/Trakx/CoinGecko/ApiClient/CoinGeckoApiConfiguration/CacheDuration
 /[environment]/Trakx/CoinGecko/ApiClient/RedisCacheConfiguration/ConnectionString
 
 # GLOBAL SECRETS
 # Instead of creating a specific repository secret, can use the global one with the same [Key]
 /[environment]/Global/CoinGeckoApiConfiguration/ApiKey
 /[environment]/Global/CoinGeckoApiConfiguration/BaseUrl
-/[environment]/Global/CoinGeckoApiConfiguration/CacheDuration
 /[environment]/Global/RedisCacheConfiguration/ConnectionString
 ```

--- a/src/Trakx.CoinGecko.ApiClient/Clients/CachedHttpClientHandler.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Clients/CachedHttpClientHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ public sealed record CachedHttpResponse(HttpStatusCode StatusCode, string Conten
 public class CachedHttpClientHandler : DelegatingHandler
 {
     private readonly IDistributedCache _cache;
-    private readonly DistributedCacheEntryOptions _cacheOptions;
+    private readonly DistributedCacheEntryOptions _cacheOptions = new();
 
     private static readonly ILogger Logger = LoggerProvider.Create<CachedHttpClientHandler>();
 
@@ -28,10 +29,10 @@ public class CachedHttpClientHandler : DelegatingHandler
     {
         _cache = cache;
 
-        _cacheOptions = new()
+        if (apiConfiguration.CacheDuration > TimeSpan.Zero)
         {
-            AbsoluteExpirationRelativeToNow = apiConfiguration.CacheDuration
-        };
+            _cacheOptions.AbsoluteExpirationRelativeToNow = apiConfiguration.CacheDuration;
+        }
     }
 
     /// <inheritdoc cref="SendAsyncInternal"/>

--- a/src/Trakx.CoinGecko.ApiClient/Configuration/CoinGeckoApiConfiguration.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Configuration/CoinGeckoApiConfiguration.cs
@@ -17,7 +17,6 @@ public record CoinGeckoApiConfiguration
     public string ApiKey { get; init; } = string.Empty;
 
     /// <summary>How long to cache requests to the API, to reuse them and reduce usage. Default is 10 seconds.</summary>
-    [AwsParameter(AllowGlobal = true)]
     public TimeSpan CacheDuration { get; init; } = TimeSpan.FromSeconds(10);
 
     /// <summary>Timeout waiting for a response from the API. Default is 10 seconds.</summary>

--- a/src/Trakx.CoinGecko.ApiClient/Configuration/CoinGeckoApiConfiguration.cs
+++ b/src/Trakx.CoinGecko.ApiClient/Configuration/CoinGeckoApiConfiguration.cs
@@ -4,27 +4,31 @@ using Trakx.Common.Extensions;
 
 namespace Trakx.CoinGecko.ApiClient;
 
+/// <summary>Main configuration for how to connect to the CoinGecko API.</summary>
 public record CoinGeckoApiConfiguration
 {
+    /// <summary>Base Url for all calls to the API. Default is https://pro-api.coingecko.com/api/v3/</summary>
+    [AwsParameter(AllowGlobal = true)]
     public Uri BaseUrl { get; init; } = Constants.ProBaseUrl;
 
-    public int MaxRetryCount { get; init; } = 10;
-
-    public TimeSpan InitialRetryDelay { get; init; } = TimeSpan.FromMilliseconds(100);
-
-    // this setting isn't used anywhere
-    public int? ThrottleDelayPerSecond { get; init; } = 120;
-
-    public TimeSpan CacheDuration { get; init; } = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// Timeout waiting for a response from the API. Default is 10 seconds.
-    /// </summary>
-    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(10);
-
-    public bool IsPro => BaseUrl.OriginalString.ContainsIgnoreCase("pro-api");
-
+    /// <summary>Access key added to all requests to the API.</summary>
     [AwsParameter(AllowGlobal = true)]
     [SecretEnvironmentVariable]
     public string ApiKey { get; init; } = string.Empty;
+
+    /// <summary>How long to cache requests to the API, to reuse them and reduce usage. Default is 10 seconds.</summary>
+    [AwsParameter(AllowGlobal = true)]
+    public TimeSpan CacheDuration { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Timeout waiting for a response from the API. Default is 10 seconds.</summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>How many attempts to retry the call to the API if it's failing. Default is 10 retries.</summary>
+    public int MaxRetryCount { get; init; } = 10;
+
+    /// <summary>Median delay to target before first retry. Subsequent retries will have exponentially longer delays. Default is 100 milliseconds.</summary>
+    public TimeSpan InitialRetryDelay { get; init; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>Is the configuration set to the PRO API (or the free API if not).</summary>
+    public bool IsPro => BaseUrl.OriginalString.ContainsIgnoreCase("pro-api");
 }

--- a/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
+++ b/src/Trakx.CoinGecko.ApiClient/Trakx.CoinGecko.ApiClient.csproj
@@ -10,19 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
-    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.0.4">
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="14.0.3">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
-    <PackageReference Include="Trakx.Common.ApiClient" Version="1.1.1" />
-    <PackageReference Include="Trakx.Common.Caching" Version="1.1.1" />
-    <PackageReference Include="Trakx.Common.Infrastructure.Caching" Version="1.1.1" />
+    <PackageReference Include="Trakx.Common.ApiClient" Version="1.1.3" />
+    <PackageReference Include="Trakx.Common.Caching" Version="1.1.3" />
+    <PackageReference Include="Trakx.Common.Infrastructure.Caching" Version="1.1.3" />
   </ItemGroup>
 
   <Target Name="NSwag" BeforeTargets="Build" Condition="'$(GenerateApiClient)'=='True' ">


### PR DESCRIPTION
- Allow `BaseUrl` to be set as AWS parameter
- `CacheDuration` should only be defined if it's a positive `TimeSpan` - otherwise the framework throws
- Add summaries to the whole configuration object
- Remove unused `ThrottleDelayPerSecond` setting
- Bump `common` packages
- Downgrade `NSwag.ApiDescription.Client` to `14.0.2` and remove NSwag.MSBuild has it's a dependency already